### PR TITLE
Support preprocessing larger corpus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
 - ${INSTALL_PREFIX}/bin/luarocks install torch
 - ${INSTALL_PREFIX}/bin/luarocks install nn
 - ${INSTALL_PREFIX}/bin/luarocks install nngraph
+- ${INSTALL_PREFIX}/bin/luarocks install tds
 - ${INSTALL_PREFIX}/bin/luarocks install bit32 || true
 - ${INSTALL_PREFIX}/bin/luarocks install luacheck
 script:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,19 @@ accuracy. Features include:
 
 ## Installation
 
-OpenNMT only requires a vanilla torch/cutorch install. It uses `nn`, `nngraph`, and `cunn`. Alternatively there is a (CUDA) <a href="https://hub.docker.com/r/harvardnlp/opennmt/">Docker container</a>.
+OpenNMT only requires a vanilla Torch install. Alternatively there is a (CUDA) <a href="https://hub.docker.com/r/harvardnlp/opennmt/">Docker container</a>.
 
+### Dependencies
+
+* `nn`
+* `nngraph`
+* `tds`
+* `threads`
+
+GPU will also require:
+
+* `cunn`
+* `cutorch`
 
 ## Quickstart
 

--- a/onmt/utils/Features.lua
+++ b/onmt/utils/Features.lua
@@ -1,3 +1,5 @@
+local tds = require('tds')
+
 --[[ Separate words and features (if any). ]]
 local function extract(tokens)
   local words = {}
@@ -58,30 +60,40 @@ local function check(label, dicts, data)
 end
 
 --[[ Generate source sequences from labels. ]]
-local function generateSource(dicts, src)
+local function generateSource(dicts, src, cdata)
   check('source', dicts, src)
 
-  local srcId = {}
+  local srcId
+  if cdata then
+    srcId = tds.Vec()
+  else
+    srcId = {}
+  end
 
   for j = 1, #dicts do
-    table.insert(srcId, dicts[j]:convertToIdx(src[j], onmt.Constants.UNK_WORD))
+    srcId[j] = dicts[j]:convertToIdx(src[j], onmt.Constants.UNK_WORD)
   end
 
   return srcId
 end
 
 --[[ Generate target sequences from labels. ]]
-local function generateTarget(dicts, tgt)
+local function generateTarget(dicts, tgt, cdata)
   check('source', dicts, tgt)
 
-  local tgtId = {}
+  local tgtId
+  if cdata then
+    tgtId = tds.Vec()
+  else
+    tgtId = {}
+  end
 
   for j = 1, #dicts do
     -- Target features are shifted relative to the target words.
     -- Use EOS tokens as a placeholder.
     table.insert(tgt[j], 1, onmt.Constants.BOS_WORD)
     table.insert(tgt[j], 1, onmt.Constants.EOS_WORD)
-    table.insert(tgtId, dicts[j]:convertToIdx(tgt[j], onmt.Constants.UNK_WORD))
+    tgtId[j] = dicts[j]:convertToIdx(tgt[j], onmt.Constants.UNK_WORD)
   end
 
   return tgtId

--- a/onmt/utils/Table.lua
+++ b/onmt/utils/Table.lua
@@ -1,3 +1,5 @@
+local tds = require('tds')
+
 --[[ Append table `src` to `dst`. ]]
 local function append(dst, src)
   for i = 1, #src do
@@ -6,11 +8,19 @@ local function append(dst, src)
 end
 
 --[[ Reorder table `tab` based on the `index` array. ]]
-local function reorder(tab, index)
-  local newTab = {}
-  for i = 1, #tab do
-    table.insert(newTab, tab[index[i]])
+local function reorder(tab, index, cdata)
+  local newTab
+  if cdata then
+    newTab = tds.Vec()
+    newTab:resize(#tab)
+  else
+    newTab = {}
   end
+
+  for i = 1, #tab do
+    newTab[i] = tab[index[i]]
+  end
+
   return newTab
 end
 

--- a/rocks/opennmt-scm-1.rockspec
+++ b/rocks/opennmt-scm-1.rockspec
@@ -15,6 +15,7 @@ description = {
 dependencies = {
    "torch >= 7.0",
    "nn >= 1.0",
+   "tds",
    "nngraph"
 }
 

--- a/train.lua
+++ b/train.lua
@@ -355,7 +355,7 @@ local function main()
     print('Loading data from \'' .. opt.data .. '\'...')
   end
 
-  local dataset = torch.load(opt.data)
+  local dataset = torch.load(opt.data, 'binary', false)
 
   local trainData = onmt.data.Dataset.new(dataset.train.src, dataset.train.tgt)
   local validData = onmt.data.Dataset.new(dataset.valid.src, dataset.valid.tgt)


### PR DESCRIPTION
These changes introduce the use of [`torch.tds`](https://github.com/torch/tds)'s vectors instead of Lua tables during the preprocessing. These data structures do not rely on the Lua memory allocator and thus, prevent the process to reach Lua's memory limit. Additionally, it just impacts the data creation code as `tds.Vec` has the same interface as a standard Lua table.

The small (and acceptable) downside is that it adds a new dependency (torch.tds) which is listed in the README.md.

I validated the change by running the preprocessing on a 16M sentences corpus and initiating a training (past the data loading step) with LuaJIT.