### PR TITLE
Move beam search options inside of translator.lua

### DIFF
--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -5,6 +5,27 @@ local opt = {}
 
 local phraseTable
 
+local function declareOpts(cmd)
+  cmd:option('-model', '', [[Path to model .t7 file]])
+
+  -- beam search options
+  cmd:text("")
+  cmd:text("**Beam Search options**")
+  cmd:text("")
+  cmd:option('-beam_size', 5,[[Beam size]])
+  cmd:option('-batch_size', 30, [[Batch size]])
+  cmd:option('-max_sent_length', 250, [[Maximum sentence length. If any sequences in srcfile are longer than this then it will error out]])
+  cmd:option('-replace_unk', false, [[Replace the generated UNK tokens with the source token that
+                              had the highest attention weight. If phrase_table is provided,
+                              it will lookup the identified source token and give the corresponding
+                              target token. If it is not provided (or the identified source token
+                              does not exist in the table) then it will copy the source token]])
+  cmd:option('-phrase_table', '', [[Path to source-target dictionary to replace UNK
+                                     tokens. See README.md for the format this file should be in]])
+  cmd:option('-n_best', 1, [[If > 1, it will also output an n_best list of decoded sentences]])
+end
+
+
 local function init(args)
   opt = args
   onmt.utils.Cuda.init(opt)
@@ -335,5 +356,6 @@ end
 
 return {
   init = init,
-  translate = translate
+  translate = translate,
+  declareOpts = declareOpts
 }

--- a/translate.lua
+++ b/translate.lua
@@ -13,26 +13,11 @@ cmd:text("")
 cmd:text("**Data options**")
 cmd:text("")
 
-cmd:option('-model', '', [[Path to model .t7 file]])
 cmd:option('-src', '', [[Source sequence to decode (one line per sequence)]])
 cmd:option('-tgt', '', [[True target sequence (optional)]])
 cmd:option('-output', 'pred.txt', [[Path to output the predictions (each line will be the decoded sequence]])
 
--- beam search options
-cmd:text("")
-cmd:text("**Beam Search options**")
-cmd:text("")
-cmd:option('-beam_size', 5,[[Beam size]])
-cmd:option('-batch_size', 30, [[Batch size]])
-cmd:option('-max_sent_length', 250, [[Maximum sentence length. If any sequences in srcfile are longer than this then it will error out]])
-cmd:option('-replace_unk', false, [[Replace the generated UNK tokens with the source token that
-                              had the highest attention weight. If phrase_table is provided,
-                              it will lookup the identified source token and give the corresponding
-                              target token. If it is not provided (or the identified source token
-                              does not exist in the table) then it will copy the source token]])
-cmd:option('-phrase_table', '', [[Path to source-target dictionary to replace UNK
-                                     tokens. See README.md for the format this file should be in]])
-cmd:option('-n_best', 1, [[If > 1, it will also output an n_best list of decoded sentences]])
+onmt.translate.Translator.declareOpts(cmd)
 
 cmd:text("")
 cmd:text("**Other options**")


### PR DESCRIPTION
Basically I want to be able to call translator from other code (translation server) and don't want to have to copy these options. Alternative is to have them be explicitly passed to a translator class but maybe this is fine for now. 