### PR TITLE
Use Logger

### DIFF
--- a/onmt/Models.lua
+++ b/onmt/Models.lua
@@ -79,7 +79,13 @@ local function buildDecoder(opt, dicts, verbose)
 
   if opt.input_feed == 1 then
     if verbose then
-      print(" * using input feeding")
+      local log
+      if _G.logger then
+        log = function (...) return _G.logger:info(...) end
+      else
+        log = print
+      end
+      log(" * using input feeding")
     end
     inputSize = inputSize + opt.rnn_size
   end

--- a/onmt/Models.lua
+++ b/onmt/Models.lua
@@ -79,13 +79,7 @@ local function buildDecoder(opt, dicts, verbose)
 
   if opt.input_feed == 1 then
     if verbose then
-      local log
-      if _G.logger then
-        log = function (...) return _G.logger:info(...) end
-      else
-        log = print
-      end
-      log(" * using input feeding")
+      _G.logger:info(" * using input feeding")
     end
     inputSize = inputSize + opt.rnn_size
   end

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -39,7 +39,13 @@ function Checkpoint:saveIteration(iteration, epochState, batchOrder, verbose)
   local filePath = string.format('%s_checkpoint.t7', self.savePath)
 
   if verbose then
-    print('Saving checkpoint to \'' .. filePath .. '\'...')
+    local log
+    if _G.logger then
+      log = function (...) return _G.logger:info(...) end
+    else
+      log = print
+    end
+    log('Saving checkpoint to \'' .. filePath .. '\'...')
   end
 
   -- Succeed serialization before overriding existing file
@@ -57,7 +63,13 @@ function Checkpoint:saveEpoch(validPpl, epochState, verbose)
   local filePath = string.format('%s_epoch%d_%.2f.t7', self.savePath, epochState.epoch, validPpl)
 
   if verbose then
-    print('Saving checkpoint to \'' .. filePath .. '\'...')
+    local log
+    if _G.logger then
+      log = function (...) return _G.logger:info(...) end
+    else
+      log = print
+    end
+    log('Saving checkpoint to \'' .. filePath .. '\'...')
   end
 
   self:save(filePath, info)

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -39,13 +39,7 @@ function Checkpoint:saveIteration(iteration, epochState, batchOrder, verbose)
   local filePath = string.format('%s_checkpoint.t7', self.savePath)
 
   if verbose then
-    local log
-    if _G.logger then
-      log = function (...) return _G.logger:info(...) end
-    else
-      log = print
-    end
-    log('Saving checkpoint to \'' .. filePath .. '\'...')
+    _G.logger:info('Saving checkpoint to \'' .. filePath .. '\'...')
   end
 
   -- Succeed serialization before overriding existing file
@@ -63,13 +57,7 @@ function Checkpoint:saveEpoch(validPpl, epochState, verbose)
   local filePath = string.format('%s_epoch%d_%.2f.t7', self.savePath, epochState.epoch, validPpl)
 
   if verbose then
-    local log
-    if _G.logger then
-      log = function (...) return _G.logger:info(...) end
-    else
-      log = print
-    end
-    log('Saving checkpoint to \'' .. filePath .. '\'...')
+    _G.logger:info('Saving checkpoint to \'' .. filePath .. '\'...')
   end
 
   self:save(filePath, info)

--- a/onmt/train/EpochState.lua
+++ b/onmt/train/EpochState.lua
@@ -35,6 +35,12 @@ end
 
 --[[ Log to status stdout. ]]
 function EpochState:log(batchIndex, json)
+  local log
+  if _G.logger then
+    log = function (...) return _G.logger:info(...) end
+  else
+    log = print
+  end
   if json then
     local freeMemory = onmt.utils.Cuda.freeMemory()
     if freeMemory < self.minFreeMemory then
@@ -66,7 +72,7 @@ function EpochState:log(batchIndex, json)
     stats = stats .. string.format('Learning rate %.4f ; ', self.learningRate)
     stats = stats .. string.format('Source tokens/s %d ; ', self.numWordsSource / timeTaken)
     stats = stats .. string.format('Perplexity %.2f', self:getTrainPpl())
-    print(stats)
+    log(stats)
   end
 end
 

--- a/onmt/train/EpochState.lua
+++ b/onmt/train/EpochState.lua
@@ -35,12 +35,6 @@ end
 
 --[[ Log to status stdout. ]]
 function EpochState:log(batchIndex, json)
-  local log
-  if _G.logger then
-    log = function (...) return _G.logger:info(...) end
-  else
-    log = print
-  end
   if json then
     local freeMemory = onmt.utils.Cuda.freeMemory()
     if freeMemory < self.minFreeMemory then
@@ -72,7 +66,7 @@ function EpochState:log(batchIndex, json)
     stats = stats .. string.format('Learning rate %.4f ; ', self.learningRate)
     stats = stats .. string.format('Source tokens/s %d ; ', self.numWordsSource / timeTaken)
     stats = stats .. string.format('Perplexity %.2f', self:getTrainPpl())
-    log(stats)
+    _G.logger:info(stats)
   end
 end
 

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -25,7 +25,13 @@ function Translator:__init(args)
   self.opt = args
   onmt.utils.Cuda.init(self.opt)
 
-  print('Loading \'' .. self.opt.model .. '\'...')
+  local log
+  if _G.logger then
+    log = function (...) return _G.logger:info(...) end
+  else
+    log = print
+  end
+  log('Loading \'' .. self.opt.model .. '\'...')
   self.checkpoint = torch.load(self.opt.model)
 
   self.models = {}

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -25,13 +25,7 @@ function Translator:__init(args)
   self.opt = args
   onmt.utils.Cuda.init(self.opt)
 
-  local log
-  if _G.logger then
-    log = function (...) return _G.logger:info(...) end
-  else
-    log = print
-  end
-  log('Loading \'' .. self.opt.model .. '\'...')
+  _G.logger:info('Loading \'' .. self.opt.model .. '\'...')
   self.checkpoint = torch.load(self.opt.model)
 
   self.models = {}

--- a/onmt/utils/Log.lua
+++ b/onmt/utils/Log.lua
@@ -1,11 +1,11 @@
-local write
-if _G.logger then
-  write = function (...) return _G.logger:write(...) end
-else
-  write = io.write
-end
 
 local function logJsonRecursive(obj)
+  local write
+  if _G.logger then
+    write = function (...) return _G.logger:write(...) end
+  else
+    write = io.write
+  end
   if type(obj) == 'string' then
     write('"' .. obj .. '"')
   elseif type(obj) == 'table' then
@@ -32,6 +32,12 @@ end
 --[[ Recursively outputs a Lua object to a JSON objects followed by a new line. ]]
 local function logJson(obj)
   logJsonRecursive(obj)
+  local write
+  if _G.logger then
+    write = function (...) return _G.logger:write(...) end
+  else
+    write = io.write
+  end
   write('\n')
 end
 

--- a/onmt/utils/Log.lua
+++ b/onmt/utils/Log.lua
@@ -1,44 +1,31 @@
-
 local function logJsonRecursive(obj)
-  local write
-  if _G.logger then
-    write = function (...) return _G.logger:write(...) end
-  else
-    write = io.write
-  end
   if type(obj) == 'string' then
-    write('"' .. obj .. '"')
+    _G.logger:write('"' .. obj .. '"')
   elseif type(obj) == 'table' then
     local first = true
 
-    write('{')
+    _G.logger:write('{')
 
     for key, val in pairs(obj) do
       if not first then
-        write(',')
+        _G.logger:write(',')
       else
         first = false
       end
-      write('"' .. key .. '":')
+      _G.logger:write('"' .. key .. '":')
       logJsonRecursive(val)
     end
 
-    write('}')
+    _G.logger:write('}')
   else
-    write(tostring(obj))
+    _G.logger:write(tostring(obj))
   end
 end
 
 --[[ Recursively outputs a Lua object to a JSON objects followed by a new line. ]]
 local function logJson(obj)
   logJsonRecursive(obj)
-  local write
-  if _G.logger then
-    write = function (...) return _G.logger:write(...) end
-  else
-    write = io.write
-  end
-  write('\n')
+  _G.logger:write('\n')
 end
 
 return {

--- a/onmt/utils/Log.lua
+++ b/onmt/utils/Log.lua
@@ -1,31 +1,38 @@
+local write
+if _G.logger then
+  write = function (...) return _G.logger:write(...) end
+else
+  write = io.write
+end
+
 local function logJsonRecursive(obj)
   if type(obj) == 'string' then
-    io.write('"' .. obj .. '"')
+    write('"' .. obj .. '"')
   elseif type(obj) == 'table' then
     local first = true
 
-    io.write('{')
+    write('{')
 
     for key, val in pairs(obj) do
       if not first then
-        io.write(',')
+        write(',')
       else
         first = false
       end
-      io.write('"' .. key .. '":')
+      write('"' .. key .. '":')
       logJsonRecursive(val)
     end
 
-    io.write('}')
+    write('}')
   else
-    io.write(tostring(obj))
+    write(tostring(obj))
   end
 end
 
 --[[ Recursively outputs a Lua object to a JSON objects followed by a new line. ]]
 local function logJson(obj)
   logJsonRecursive(obj)
-  io.write('\n')
+  write('\n')
 end
 
 return {

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -43,6 +43,7 @@ function Logger:__init(logPath, mute)
   else
     self.logFile = nil
   end
+  self.LEVELS = { DEBUG = 0, INFO = 1, WARNING = 2, ERROR = 3 }
 end
 
 --[[ Log a message at a specified level.
@@ -56,10 +57,10 @@ function Logger:log(message, level)
   level = level or 'INFO'
   local timeStamp = os.date('%x %X')
   local msgFormatted = string.format('[%s %s] %s', timeStamp, level, message)
-  if not self.mute then
+  if (not self.mute) and self:_isVisible(level) then
     print (msgFormatted)
   end
-  if self.logFile then
+  if self.logFile and self:_isVisible(level) then
     self.logFile:write(msgFormatted .. '\n')
     self.logFile:flush()
   end
@@ -95,6 +96,16 @@ function Logger:error(...)
   self:log(string.format(...), 'ERROR')
 end
 
+--[[ Log a message at 'DEBUG' level.
+
+Parameters:
+  * `message` - the message to log. Supports formatting string.
+
+]]
+function Logger:debug(...)
+  self:log(string.format(...), 'DEBUG')
+end
+
 --[[ Log a message as exactly it is.
 
 Parameters:
@@ -103,13 +114,36 @@ Parameters:
 ]]
 function Logger:write(...)
   local msg = string.format(...)
-  if not self.mute then
-    print (msg)
+  if (not self.mute) and self:_isVisible('WARNING') then
+    io.write(msg)
   end
-  if self.logFile then
+  if self.logFile and self:_isVisible('WARNING') then
     self.logFile:write(msg)
     self.logFile:flush()
   end
+end
+
+--[[ Set the visible message level. Lower level messages will be muted.
+
+Parameters:
+  * `level` - 'DEBUG', 'INFO', 'WARNING' or 'ERROR'.
+
+]]
+function Logger:setVisibleLevel(level)
+  assert (level == 'DEBUG' or level == 'INFO' or
+          level == 'WARNING' or level == 'ERROR')
+  self.level = level
+end
+
+--[[Private function for comparing level against visible level.
+
+Parameters:
+  * `level` - 'DEBUG', 'INFO', 'WARNING' or 'ERROR'.
+
+]]
+function Logger:_isVisible(level)
+  self.level = self.level or 'INFO'
+  return self.LEVELS[level] >= self.LEVELS[self.level]
 end
 
 --[[ Deconstructor. Close the log file.

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -5,52 +5,36 @@ local Logger = torch.class('Logger')
 function Logger.declareOpts(cmd)
   cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
   cmd:option('-disable_logs', false, [[If = true, output nothing.]])
+  cmd:option('-log_level', 'INFO', [[Outputs logs at this level and above. Possible options are: DEBUG, INFO, WARNING and ERROR.]])
 end
 
 --[[ Construct a Logger object.
 
 Parameters:
-  * `args` - options.
+  * `logFile` - Outputs logs to a file under this path instead of stdout. ['']
+  * `disableLogs` - If = true, output nothing. [false]
+  * `logLevel` - Outputs logs at this level and above. Possible options are: DEBUG, INFO, WARNING and ERROR. ['INFO']
 
 Example:
 
-    local cmd = torch.CmdLine()
-    onmt.utils.Logger.declareOpts(cmd)
-    opt = cmd:parse(arg)
-    logger = onmt.utils.Logger.new(opt)
+    logger = onmt.utils.Logger.new('log.txt')
     logger:info('%s is an extension of OpenNMT.', 'Im2Text')
     logger:shutDown()
 
 ]]
-function Logger:__init(args)
-  if args then
-    local mute = (args.log_file:len() > 0)
-    self:build(args.log_file, mute)
-    if args.disable_logs then
-      self:setVisibleLevel('ERROR')
-    end
+function Logger:__init(logFile, disableLogs, logLevel)
+  logFile = logFile or ''
+  disableLogs = disableLogs or false
+  logLevel = logLevel or 'INFO'
+
+  self.mute = (logFile:len() > 0)
+  if disableLogs then
+    self:setVisibleLevel('ERROR')
+  else
+    self:setVisibleLevel(logLevel)
   end
-end
-
---[[ Build a Logger object.
-
-Parameters:
-  * `logPath` - the path to log file.
-  * `mute` - whether or not suppress outputs to stdout. [false]
-
-Example:
-
-    logger = onmt.utils.Logger.new():build("./log.txt")
-    logger:info('%s is an extension of OpenNMT.', 'Im2Text')
-    logger:shutDown()
-
-]]
-function Logger:build(logPath, mute)
-  logPath = logPath or ''
-  mute = mute or false
-  self.mute = mute
   local openMode = 'w'
-  local f = io.open(logPath, 'r')
+  local f = io.open(logFile, 'r')
   if f then
     f:close()
     local input = nil
@@ -68,13 +52,12 @@ function Logger:build(logPath, mute)
       end
     end
   end
-  if string.len(logPath) > 0 then
-    self.logFile = io.open(logPath, openMode)
+  if string.len(logFile) > 0 then
+    self.logFile = io.open(logFile, openMode)
   else
     self.logFile = nil
   end
   self.LEVELS = { DEBUG = 0, INFO = 1, WARNING = 2, ERROR = 3 }
-  return self
 end
 
 --[[ Log a message at a specified level.

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -135,7 +135,7 @@ function Logger:setVisibleLevel(level)
   self.level = level
 end
 
--- Private function for comparing level against visible level. 
+-- Private function for comparing level against visible level.
 -- `level` - 'DEBUG', 'INFO', 'WARNING' or 'ERROR'.
 function Logger:_isVisible(level)
   self.level = self.level or 'INFO'

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -73,7 +73,7 @@ Parameters:
 
 ]]
 function Logger:info(...)
-  self:log(string.format(...), 'INFO')
+  self:log(self:_format(...), 'INFO')
 end
 
 --[[ Log a message at 'WARNING' level.
@@ -83,7 +83,7 @@ Parameters:
 
 ]]
 function Logger:warning(...)
-  self:log(string.format(...), 'WARNING')
+  self:log(self:_format(...), 'WARNING')
 end
 
 --[[ Log a message at 'ERROR' level.
@@ -93,7 +93,7 @@ Parameters:
 
 ]]
 function Logger:error(...)
-  self:log(string.format(...), 'ERROR')
+  self:log(self:_format(...), 'ERROR')
 end
 
 --[[ Log a message at 'DEBUG' level.
@@ -103,7 +103,7 @@ Parameters:
 
 ]]
 function Logger:debug(...)
-  self:log(string.format(...), 'DEBUG')
+  self:log(self:_format(...), 'DEBUG')
 end
 
 --[[ Log a message as exactly it is.
@@ -113,7 +113,7 @@ Parameters:
 
 ]]
 function Logger:write(...)
-  local msg = string.format(...)
+  local msg = self:_format(...)
   if (not self.mute) and self:_isVisible('WARNING') then
     io.write(msg)
   end
@@ -135,15 +135,19 @@ function Logger:setVisibleLevel(level)
   self.level = level
 end
 
---[[Private function for comparing level against visible level.
-
-Parameters:
-  * `level` - 'DEBUG', 'INFO', 'WARNING' or 'ERROR'.
-
-]]
+-- Private function for comparing level against visible level. 
+-- `level` - 'DEBUG', 'INFO', 'WARNING' or 'ERROR'.
 function Logger:_isVisible(level)
   self.level = self.level or 'INFO'
   return self.LEVELS[level] >= self.LEVELS[self.level]
+end
+
+function Logger:_format(...)
+  if #table.pack(...) == 1 then
+    return ...
+  else
+    return string.format(...)
+  end
 end
 
 --[[ Deconstructor. Close the log file.

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -2,7 +2,37 @@
 --]]
 local Logger = torch.class('Logger')
 
+function Logger.declareOpts(cmd)
+  cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
+  cmd:option('-disable_logs', false, [[If = true, output nothing.]])
+end
+
 --[[ Construct a Logger object.
+
+Parameters:
+  * `args` - options.
+
+Example:
+
+    local cmd = torch.CmdLine()
+    onmt.utils.Logger.declareOpts(cmd)
+    opt = cmd:parse(arg)
+    logger = onmt.utils.Logger.new(opt)
+    logger:info('%s is an extension of OpenNMT.', 'Im2Text')
+    logger:shutDown()
+
+]]
+function Logger:__init(args)
+  if args then
+    local mute = (args.log_file:len() > 0)
+    self:build(args.log_file, mute)
+    if args.disable_logs then
+      self:setVisibleLevel('ERROR')
+    end
+  end
+end
+
+--[[ Build a Logger object.
 
 Parameters:
   * `logPath` - the path to log file.
@@ -10,12 +40,12 @@ Parameters:
 
 Example:
 
-    logger = onmt.utils.Logger.new("./log.txt")
+    logger = onmt.utils.Logger.new():build("./log.txt")
     logger:info('%s is an extension of OpenNMT.', 'Im2Text')
     logger:shutDown()
 
 ]]
-function Logger:__init(logPath, mute)
+function Logger:build(logPath, mute)
   logPath = logPath or ''
   mute = mute or false
   self.mute = mute
@@ -44,6 +74,7 @@ function Logger:__init(logPath, mute)
     self.logFile = nil
   end
   self.LEVELS = { DEBUG = 0, INFO = 1, WARNING = 2, ERROR = 3 }
+  return self
 end
 
 --[[ Log a message at a specified level.

--- a/onmt/utils/Logger.lua
+++ b/onmt/utils/Logger.lua
@@ -5,14 +5,14 @@ local Logger = torch.class('Logger')
 --[[ Construct a Logger object.
 
 Parameters:
-  * `logPath` - the path to log file. If left blank, then output log to stdout.
+  * `logPath` - the path to log file.
   * `mute` - whether or not suppress outputs to stdout. [false]
 
 Example:
 
-    logging = onmt.utils.Logger.new("./log.txt")
-    logging:info('%s is an extension of OpenNMT.', 'Im2Text')
-    logging:shutDown()
+    logger = onmt.utils.Logger.new("./log.txt")
+    logger:info('%s is an extension of OpenNMT.', 'Im2Text')
+    logger:shutDown()
 
 ]]
 function Logger:__init(logPath, mute)
@@ -42,7 +42,6 @@ function Logger:__init(logPath, mute)
     self.logFile = io.open(logPath, openMode)
   else
     self.logFile = nil
-    self.mute = false
   end
 end
 
@@ -94,6 +93,23 @@ Parameters:
 ]]
 function Logger:error(...)
   self:log(string.format(...), 'ERROR')
+end
+
+--[[ Log a message as exactly it is.
+
+Parameters:
+  * `message` - the message to log. Supports formatting string.
+
+]]
+function Logger:write(...)
+  local msg = string.format(...)
+  if not self.mute then
+    print (msg)
+  end
+  if self.logFile then
+    self.logFile:write(msg)
+    self.logFile:flush()
+  end
 end
 
 --[[ Deconstructor. Close the log file.

--- a/onmt/utils/Memory.lua
+++ b/onmt/utils/Memory.lua
@@ -18,14 +18,8 @@ Example:
 ]]
 function Memory.optimize(model, criterion, batch, verbose)
 
-  local log
-  if _G.logger then
-    log = function (...) return _G.logger:info(...) end
-  else
-    log = print
-  end
   if verbose then
-    log('Preparing memory optimization...')
+    _G.logger:info('Preparing memory optimization...')
   end
 
   -- Prepare memory optimization

--- a/onmt/utils/Memory.lua
+++ b/onmt/utils/Memory.lua
@@ -42,7 +42,7 @@ function Memory.optimize(model, criterion, batch, verbose)
   local sharedSize, totSize = memoryOptimizer:optimize()
 
   if verbose then
-    log(' * sharing %d%% of output/gradInput tensors memory between clones', (sharedSize / totSize)*100)
+    _G.logger:info(' * sharing %d%% of output/gradInput tensors memory between clones', (sharedSize / totSize)*100)
   end
 
   -- Restore batch to be transparent for the calling code.

--- a/onmt/utils/Memory.lua
+++ b/onmt/utils/Memory.lua
@@ -17,8 +17,15 @@ Example:
 
 ]]
 function Memory.optimize(model, criterion, batch, verbose)
+
+  local log
+  if _G.logger then
+    log = function (...) return _G.logger:info(...) end
+  else
+    log = print
+  end
   if verbose then
-    print('Preparing memory optimization...')
+    log('Preparing memory optimization...')
   end
 
   -- Prepare memory optimization
@@ -41,7 +48,7 @@ function Memory.optimize(model, criterion, batch, verbose)
   local sharedSize, totSize = memoryOptimizer:optimize()
 
   if verbose then
-    print(string.format(' * sharing %d%% of output/gradInput tensors memory between clones', (sharedSize / totSize)*100))
+    log(' * sharing %d%% of output/gradInput tensors memory between clones', (sharedSize / totSize)*100)
   end
 
   -- Restore batch to be transparent for the calling code.

--- a/onmt/utils/Parallel.lua
+++ b/onmt/utils/Parallel.lua
@@ -36,8 +36,16 @@ function Parallel.init(opt)
     Parallel.gradBuffer = onmt.utils.Cuda.convert(Parallel.gradBuffer)
     Parallel._tds = require('tds')
 
+    local log, warn
+    if _G.logger then
+      log = function (...) return _G.logger:info(...) end
+      warn = function (...) return _G.logger:warning(...) end
+    else
+      log, warn = print, print
+    end
+
     if Parallel.count > 1 then
-      print('Using ' .. Parallel.count .. ' threads on ' .. #Parallel.gpus .. ' GPUs')
+      log('Using ' .. Parallel.count .. ' threads on ' .. #Parallel.gpus .. ' GPUs')
       local threads = require('threads')
       threads.Threads.serialization('threads.sharedserialize')
       local thegpus = Parallel.gpus
@@ -60,10 +68,10 @@ function Parallel.init(opt)
       local ret
       ret, Parallel.usenccl = pcall(require, 'nccl')
       if not ret then
-        print("WARNING: for improved efficiency in nparallel mode - do install nccl")
+        warn("For improved efficiency in nparallel mode - do install nccl")
         Parallel.usenccl = nil
       elseif os.getenv('CUDA_LAUNCH_BLOCKING') == '1' then
-        print("WARNING: CUDA_LAUNCH_BLOCKING set - cannot use nccl")
+        warn("CUDA_LAUNCH_BLOCKING set - cannot use nccl")
         Parallel.usenccl = nil
       end
     end

--- a/onmt/utils/Parallel.lua
+++ b/onmt/utils/Parallel.lua
@@ -36,16 +36,8 @@ function Parallel.init(opt)
     Parallel.gradBuffer = onmt.utils.Cuda.convert(Parallel.gradBuffer)
     Parallel._tds = require('tds')
 
-    local log, warn
-    if _G.logger then
-      log = function (...) return _G.logger:info(...) end
-      warn = function (...) return _G.logger:warning(...) end
-    else
-      log, warn = print, print
-    end
-
     if Parallel.count > 1 then
-      log('Using ' .. Parallel.count .. ' threads on ' .. #Parallel.gpus .. ' GPUs')
+      _G.logger:info('Using ' .. Parallel.count .. ' threads on ' .. #Parallel.gpus .. ' GPUs')
       local threads = require('threads')
       threads.Threads.serialization('threads.sharedserialize')
       local thegpus = Parallel.gpus
@@ -68,10 +60,10 @@ function Parallel.init(opt)
       local ret
       ret, Parallel.usenccl = pcall(require, 'nccl')
       if not ret then
-        warn("For improved efficiency in nparallel mode - do install nccl")
+        _G.logger:warning("For improved efficiency in nparallel mode - do install nccl")
         Parallel.usenccl = nil
       elseif os.getenv('CUDA_LAUNCH_BLOCKING') == '1' then
-        warn("CUDA_LAUNCH_BLOCKING set - cannot use nccl")
+        _G.logger:warning("CUDA_LAUNCH_BLOCKING set - cannot use nccl")
         Parallel.usenccl = nil
       end
     end

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -277,13 +277,11 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local logFile = opt.log_file
   local mute = (opt.log_file:len() > 0)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
   if opt.disable_logs then
-    logFile = nil
-    mute = true
+    _G.logger:setVisibleLevel('ERROR')
   end
-  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   local data = {}
 

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -277,7 +277,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  _G.logger = onmt.utils.Logger.new(opt)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   local data = {}
 

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -189,7 +189,7 @@ local function makeData(srcFile, tgtFile, srcDicts, tgtDicts)
 
     if srcTokens == nil or tgtTokens == nil then
       if srcTokens == nil and tgtTokens ~= nil or srcTokens ~= nil and tgtTokens == nil then
-        _G.logger:info('WARNING: source and target do not have the same number of sentences')
+        _G.logger:warning('source and target do not have the same number of sentences')
       end
       break
     end

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -32,8 +32,8 @@ cmd:option('-shuffle', 1, [[Shuffle data]])
 cmd:option('-seed', 3435, [[Random seed]])
 
 cmd:option('-report_every', 100000, [[Report status every this many sentences]])
-cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout]])
-cmd:option('-disable_logs', false, [[Outputs nothing]])
+
+onmt.utils.Logger.declareOpts(cmd)
 
 local opt = cmd:parse(arg)
 
@@ -277,11 +277,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local mute = (opt.log_file:len() > 0)
-  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
-  if opt.disable_logs then
-    _G.logger:setVisibleLevel('ERROR')
-  end
+  _G.logger = onmt.utils.Logger.new(opt)
 
   local data = {}
 

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -277,7 +277,13 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  _G.logger = onmt.utils.Logger.new(opt.log_file, true)
+  local logFile = opt.log_file
+  local mute = (opt.log_file:len() > 0)
+  if opt.disable_logs then
+    logFile = nil
+    mute = true
+  end
+  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   local data = {}
 
@@ -314,7 +320,7 @@ local function main()
 
   _G.logger:info('Saving data to \'' .. opt.save_data .. '-train.t7\'...')
   torch.save(opt.save_data .. '-train.t7', data, 'binary', false)
-
+  _G.logger:shutDown()
 end
 
 main()

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -250,8 +250,8 @@ local function makeData(srcFile, tgtFile, srcDicts, tgtDicts)
   reorderData(perm)
 
   _G.logger:info('Prepared ' .. #src .. ' sentences (' .. ignored
-          .. ' ignored due to source length > ' .. opt.src_seq_length
-          .. ' or target length > ' .. opt.tgt_seq_length .. ')')
+                   .. ' ignored due to source length > ' .. opt.src_seq_length
+                   .. ' or target length > ' .. opt.tgt_seq_length .. ')')
 
   local srcData = {
     words = src,

--- a/test/test.lua
+++ b/test/test.lua
@@ -188,12 +188,12 @@ end
 tester:add(dictTest)
 
 
-function main()
+local function main()
   -- Limit number of threads since everything is small
   local nThreads = torch.getnumthreads()
   torch.setnumthreads(1)
 
-  tester:run(tests)
+  tester:run()
 
   torch.setnumthreads(nThreads)
 

--- a/tools/release_model.lua
+++ b/tools/release_model.lua
@@ -25,13 +25,11 @@ end
 local function main()
   assert(path.exists(opt.model), 'model \'' .. opt.model .. '\' does not exist.')
 
-  local logFile = opt.log_file
   local mute = (opt.log_file:len() > 0)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
   if opt.disable_logs then
-    logFile = nil
-    mute = true
+    _G.logger:setVisibleLevel('ERROR')
   end
-  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   if opt.output_model:len() == 0 then
     if opt.model:sub(-3) == '.t7' then

--- a/tools/release_model.lua
+++ b/tools/release_model.lua
@@ -24,7 +24,7 @@ end
 local function main()
   assert(path.exists(opt.model), 'model \'' .. opt.model .. '\' does not exist.')
 
-  _G.logger = onmt.utils.Logger.new(opt)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   if opt.output_model:len() == 0 then
     if opt.model:sub(-3) == '.t7' then

--- a/tools/release_model.lua
+++ b/tools/release_model.lua
@@ -7,6 +7,8 @@ cmd:option('-model', '', 'trained model file')
 cmd:option('-output_model', '', 'released model file')
 cmd:option('-gpuid', 0, [[1-based identifier of the GPU to use. CPU is used when the option is < 1]])
 cmd:option('-force', false, 'force output model creation')
+cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
+cmd:option('-disable_logs', false, [[If = true, output nothing.]])
 local opt = cmd:parse(arg)
 
 local function toCPU(model)
@@ -22,6 +24,14 @@ end
 
 local function main()
   assert(path.exists(opt.model), 'model \'' .. opt.model .. '\' does not exist.')
+
+  local logFile = opt.log_file
+  local mute = (opt.log_file:len() > 0)
+  if opt.disable_logs then
+    logFile = nil
+    mute = true
+  end
+  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   if opt.output_model:len() == 0 then
     if opt.model:sub(-3) == '.t7' then
@@ -42,7 +52,7 @@ local function main()
     cutorch.setDevice(opt.gpuid)
   end
 
-  print('Loading model \'' .. opt.model .. '\'...')
+  _G.logger:info('Loading model \'' .. opt.model .. '\'...')
 
   local checkpoint
   local _, err = pcall(function ()
@@ -52,18 +62,20 @@ local function main()
     error('unable to load the model (' .. err .. '). If you are releasing a GPU model, it needs to be loaded on the GPU first (set -gpuid > 0)')
   end
 
-  print('... done.')
+  _G.logger:info('... done.')
 
-  print('Converting model...')
+  _G.logger:info('Converting model...')
   checkpoint.info = nil
   for _, model in pairs(checkpoint.models) do
     toCPU(model)
   end
-  print('... done.')
+  _G.logger:info('... done.')
 
-  print('Releasing model \'' .. opt.output_model .. '\'...')
+  _G.logger:info('Releasing model \'' .. opt.output_model .. '\'...')
   torch.save(opt.output_model, checkpoint)
-  print('... done.')
+  _G.logger:info('... done.')
+
+  _G.logger:shutDown()
 end
 
 main()

--- a/tools/release_model.lua
+++ b/tools/release_model.lua
@@ -7,8 +7,7 @@ cmd:option('-model', '', 'trained model file')
 cmd:option('-output_model', '', 'released model file')
 cmd:option('-gpuid', 0, [[1-based identifier of the GPU to use. CPU is used when the option is < 1]])
 cmd:option('-force', false, 'force output model creation')
-cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
-cmd:option('-disable_logs', false, [[If = true, output nothing.]])
+onmt.utils.Logger.declareOpts(cmd)
 local opt = cmd:parse(arg)
 
 local function toCPU(model)
@@ -25,11 +24,7 @@ end
 local function main()
   assert(path.exists(opt.model), 'model \'' .. opt.model .. '\' does not exist.')
 
-  local mute = (opt.log_file:len() > 0)
-  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
-  if opt.disable_logs then
-    _G.logger:setVisibleLevel('ERROR')
-  end
+  _G.logger = onmt.utils.Logger.new(opt)
 
   if opt.output_model:len() == 0 then
     if opt.model:sub(-3) == '.t7' then

--- a/tools/translation_server.lua
+++ b/tools/translation_server.lua
@@ -19,8 +19,7 @@ cmd:text("**Other options**")
 cmd:text("")
 cmd:option('-gpuid', -1, [[ID of the GPU to use (-1 = use CPU, 0 = let cuda choose between available GPUs)]])
 cmd:option('-fallback_to_cpu', false, [[If = true, fallback to CPU if no GPU available]])
-cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
-cmd:option('-disable_logs', false, [[If = true, output nothing.]])
+onmt.utils.Logger.declareOpts(cmd)
 
 
 local function translateMessage(translator, lines)
@@ -79,11 +78,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local mute = (opt.log_file:len() > 0)
-  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
-  if opt.disable_logs then
-    _G.logger:setVisibleLevel('ERROR')
-  end
+  _G.logger = onmt.utils.Logger.new(opt)
 
   _G.logger:info("Loading model")
   local translator = onmt.translate.Translator.new(opt)

--- a/tools/translation_server.lua
+++ b/tools/translation_server.lua
@@ -78,7 +78,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  _G.logger = onmt.utils.Logger.new(opt)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   _G.logger:info("Loading model")
   local translator = onmt.translate.Translator.new(opt)

--- a/tools/translation_server.lua
+++ b/tools/translation_server.lua
@@ -106,7 +106,6 @@ local function main()
     _G.logger:info("Returning... " .. ret)
     collectgarbage()
   end
-  _G.logger:shutDown()
 end
 
 main()

--- a/tools/translation_server.lua
+++ b/tools/translation_server.lua
@@ -79,13 +79,11 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local logFile = opt.log_file
   local mute = (opt.log_file:len() > 0)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
   if opt.disable_logs then
-    logFile = nil
-    mute = true
+    _G.logger:setVisibleLevel('ERROR')
   end
-  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   _G.logger:info("Loading model")
   local translator = onmt.translate.Translator.new(opt)

--- a/train.lua
+++ b/train.lua
@@ -468,7 +468,7 @@ local function main()
 
       if not opt.json_log then
         _G.logger:info('Resuming training from epoch ' .. opt.start_epoch
-                       .. ' at iteration ' .. opt.start_iteration .. '...')
+                         .. ' at iteration ' .. opt.start_iteration .. '...')
       end
     end
   end

--- a/train.lua
+++ b/train.lua
@@ -434,7 +434,7 @@ local function main()
   onmt.utils.Cuda.init(opt)
   onmt.utils.Parallel.init(opt)
 
-  _G.logger = onmt.utils.Logger.new(opt)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   local checkpoint = {}
 
@@ -468,7 +468,7 @@ local function main()
 
       if not opt.json_log then
         _G.logger:info('Resuming training from epoch ' .. opt.start_epoch
-                .. ' at iteration ' .. opt.start_iteration .. '...')
+                       .. ' at iteration ' .. opt.start_iteration .. '...')
       end
     end
   end
@@ -488,11 +488,11 @@ local function main()
 
   if not opt.json_log then
     _G.logger:info(' * vocabulary size: source = %d; target = %d',
-                        dataset.dicts.src.words:size(), dataset.dicts.tgt.words:size())
+                   dataset.dicts.src.words:size(), dataset.dicts.tgt.words:size())
     _G.logger:info(' * additional features: source = %d; target = %d',
-                        #dataset.dicts.src.features, #dataset.dicts.tgt.features)
+                   #dataset.dicts.src.features, #dataset.dicts.tgt.features)
     _G.logger:info(' * maximum sequence length: source = %d; target = %d',
-                        trainData.maxSourceLength, trainData.maxTargetLength)
+                   trainData.maxSourceLength, trainData.maxTargetLength)
     _G.logger:info(' * number of training sentences: %d', #trainData.src)
     _G.logger:info(' * maximum batch size: %d', opt.max_batch_size)
   else

--- a/train.lua
+++ b/train.lua
@@ -85,8 +85,8 @@ cmd:option('-save_every', 0, [[Save intermediate models every this many iteratio
 cmd:option('-report_every', 50, [[Print stats every this many iterations within an epoch.]])
 cmd:option('-seed', 3435, [[Seed for random initialization]])
 cmd:option('-json_log', false, [[Outputs logs in JSON format.]])
-cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout.]])
-cmd:option('-disable_logs', false, [[If = true, output nothing.]])
+
+onmt.utils.Logger.declareOpts(cmd)
 
 local opt = cmd:parse(arg)
 
@@ -434,11 +434,7 @@ local function main()
   onmt.utils.Cuda.init(opt)
   onmt.utils.Parallel.init(opt)
 
-  local mute = (opt.log_file:len() > 0)
-  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
-  if opt.disable_logs then
-    _G.logger:setVisibleLevel('ERROR')
-  end
+  _G.logger = onmt.utils.Logger.new(opt)
 
   local checkpoint = {}
 

--- a/train.lua
+++ b/train.lua
@@ -434,13 +434,11 @@ local function main()
   onmt.utils.Cuda.init(opt)
   onmt.utils.Parallel.init(opt)
 
-  local logFile = opt.log_file
   local mute = (opt.log_file:len() > 0)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
   if opt.disable_logs then
-    logFile = nil
-    mute = true
+    _G.logger:setVisibleLevel('ERROR')
   end
-  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   local checkpoint = {}
 

--- a/translate.lua
+++ b/translate.lua
@@ -45,13 +45,11 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local logFile = opt.log_file
   local mute = (opt.log_file:len() > 0)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
   if opt.disable_logs then
-    logFile = nil
-    mute = true
+    _G.logger:setVisibleLevel('ERROR')
   end
-  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   local srcReader = onmt.utils.FileReader.new(opt.src)
   local srcBatch = {}

--- a/translate.lua
+++ b/translate.lua
@@ -25,9 +25,8 @@ cmd:text("")
 cmd:option('-gpuid', 0, [[1-based identifier of the GPU to use. CPU is used when the option is < 1]])
 cmd:option('-fallback_to_cpu', false, [[If = true, fallback to CPU if no GPU available]])
 cmd:option('-time', false, [[Measure batch translation time]])
-cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout]])
-cmd:option('-disable_logs', false, [[If = true, output nothing]])
 
+onmt.utils.Logger.declareOpts(cmd)
 
 local function reportScore(name, scoreTotal, wordsTotal)
   _G.logger:info(name .. " AVG SCORE: %.4f, " .. name .. " PPL: %.4f",
@@ -45,11 +44,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  local mute = (opt.log_file:len() > 0)
-  _G.logger = onmt.utils.Logger.new(opt.log_file, mute)
-  if opt.disable_logs then
-    _G.logger:setVisibleLevel('ERROR')
-  end
+  _G.logger = onmt.utils.Logger.new(opt)
 
   local srcReader = onmt.utils.FileReader.new(opt.src)
   local srcBatch = {}

--- a/translate.lua
+++ b/translate.lua
@@ -25,12 +25,14 @@ cmd:text("")
 cmd:option('-gpuid', 0, [[1-based identifier of the GPU to use. CPU is used when the option is < 1]])
 cmd:option('-fallback_to_cpu', false, [[If = true, fallback to CPU if no GPU available]])
 cmd:option('-time', false, [[Measure batch translation time]])
+cmd:option('-log_file', '', [[Outputs logs to a file under this path instead of stdout]])
+cmd:option('-disable_logs', false, [[If = true, output nothing]])
 
 
 local function reportScore(name, scoreTotal, wordsTotal)
-  print(string.format(name .. " AVG SCORE: %.4f, " .. name .. " PPL: %.4f",
+  _G.logger:info(name .. " AVG SCORE: %.4f, " .. name .. " PPL: %.4f",
                       scoreTotal / wordsTotal,
-                      math.exp(-scoreTotal/wordsTotal)))
+                      math.exp(-scoreTotal/wordsTotal))
 end
 
 local function main()
@@ -42,6 +44,14 @@ local function main()
   }
 
   onmt.utils.Opt.init(opt, requiredOptions)
+
+  local logFile = opt.log_file
+  local mute = (opt.log_file:len() > 0)
+  if opt.disable_logs then
+    logFile = nil
+    mute = true
+  end
+  _G.logger = onmt.utils.Logger.new(logFile, mute)
 
   local srcReader = onmt.utils.FileReader.new(opt.src)
   local srcBatch = {}
@@ -126,9 +136,9 @@ local function main()
 
         outFile:write(predSent .. '\n')
 
-        print('SENT ' .. sentId .. ': ' .. srcSent)
-        print('PRED ' .. sentId .. ': ' .. predSent)
-        print(string.format("PRED SCORE: %.4f", info[b].score))
+        _G.logger:info('SENT ' .. sentId .. ': ' .. srcSent)
+        _G.logger:info('PRED ' .. sentId .. ': ' .. predSent)
+        _G.logger:info("PRED SCORE: %.4f", info[b].score)
 
         predScoreTotal = predScoreTotal + info[b].score
         predWordsTotal = predWordsTotal + #predBatch[b]
@@ -136,22 +146,22 @@ local function main()
         if withGoldScore then
           local tgtSent = table.concat(tgtBatch[b], " ")
 
-          print('GOLD ' .. sentId .. ': ' .. tgtSent)
-          print(string.format("GOLD SCORE: %.4f", info[b].goldScore))
+          _G.logger:info('GOLD ' .. sentId .. ': ' .. tgtSent)
+          _G.logger:info("GOLD SCORE: %.4f", info[b].goldScore)
 
           goldScoreTotal = goldScoreTotal + info[b].goldScore
           goldWordsTotal = goldWordsTotal + #tgtBatch[b]
         end
 
         if opt.n_best > 1 then
-          print('\nBEST HYP:')
+          _G.logger:info('\nBEST HYP:')
           for n = 1, #info[b].nBest do
             local nBest = table.concat(info[b].nBest[n].tokens, " ")
-            print(string.format("[%.4f] %s", info[b].nBest[n].score, nBest))
+            _G.logger:info("[%.4f] %s", info[b].nBest[n].score, nBest)
           end
         end
 
-        print('')
+        _G.logger:info('')
         sentId = sentId + 1
       end
 
@@ -175,10 +185,10 @@ local function main()
   if opt.time then
     local time = timer:time()
     local sentenceCount = sentId-1
-    io.stderr:write("Average sentence translation time (in seconds):\n")
-    io.stderr:write("avg real\t" .. time.real / sentenceCount .. "\n")
-    io.stderr:write("avg user\t" .. time.user / sentenceCount .. "\n")
-    io.stderr:write("avg sys\t" .. time.sys / sentenceCount .. "\n")
+    _G.logger:info("Average sentence translation time (in seconds):\n")
+    _G.logger:info("avg real\t" .. time.real / sentenceCount .. "\n")
+    _G.logger:info("avg user\t" .. time.user / sentenceCount .. "\n")
+    _G.logger:info("avg sys\t" .. time.sys / sentenceCount .. "\n")
   end
 
   reportScore('PRED', predScoreTotal, predWordsTotal)
@@ -188,6 +198,7 @@ local function main()
   end
 
   outFile:close()
+  _G.logger:shutDown()
 end
 
 main()

--- a/translate.lua
+++ b/translate.lua
@@ -30,8 +30,8 @@ onmt.utils.Logger.declareOpts(cmd)
 
 local function reportScore(name, scoreTotal, wordsTotal)
   _G.logger:info(name .. " AVG SCORE: %.4f, " .. name .. " PPL: %.4f",
-                      scoreTotal / wordsTotal,
-                      math.exp(-scoreTotal/wordsTotal))
+                 scoreTotal / wordsTotal,
+                 math.exp(-scoreTotal/wordsTotal))
 end
 
 local function main()
@@ -44,7 +44,7 @@ local function main()
 
   onmt.utils.Opt.init(opt, requiredOptions)
 
-  _G.logger = onmt.utils.Logger.new(opt)
+  _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   local srcReader = onmt.utils.FileReader.new(opt.src)
   local srcBatch = {}


### PR DESCRIPTION
Replace print with Logger, which allows printing timestamps and log levels, as well as produces warnings with options if the log file already exists. The two options added are: `-log_file`, which specifies the path to the log file, (if left blank, output to stdout); and `-disable_logs`, which would suppress all outputs.