### PR TITLE
fix allow memory access between devices

### DIFF
--- a/onmt/utils/Cuda.lua
+++ b/onmt/utils/Cuda.lua
@@ -35,7 +35,7 @@ function Cuda.init(opt, masterGPU)
       _G.logger:info('Using GPU(s): ' .. table.concat(Cuda.gpuIds, ', '))
 
       -- Allow memory access between devices.
-      cutorch.getKernelPeerToPeerAccess(true)
+      cutorch.setKernelPeerToPeerAccess(true)
 
       if opt.seed then
         cutorch.manualSeedAll(opt.seed)


### PR DESCRIPTION
Allow memory access between devices should be cutorch.setKernelPeerToPeerAccess(true), not cutorch.getKernelPeerToPeerAccess(true), according to the cutorch document.