### PR TITLE
Add partial CuDNN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 
 * Add TensorBoard metrics visualisation with [Crayon](https://github.com/torrvision/crayon)
+* Add partial CuDNN support (unidirectional LSTM and GRU)
 
 ### Fixes and improvements
 

--- a/onmt/data/Batch.lua
+++ b/onmt/data/Batch.lua
@@ -196,7 +196,7 @@ end
 local function addInputFeatures(inputs, featuresSeq, t)
   local features = {}
   for j = 1, #featuresSeq do
-    table.insert(features, featuresSeq[j][t])
+    table.insert(features, (t and featuresSeq[j][t]) or featuresSeq[j]:t())
   end
   if #features > 1 then
     table.insert(inputs, features)
@@ -205,10 +205,10 @@ local function addInputFeatures(inputs, featuresSeq, t)
   end
 end
 
---[[ Get source input batch at timestep `t`. --]]
+--[[ Get source input batch at timestep `t`. If `t` is nil, returns the whole sequence. --]]
 function Batch:getSourceInput(t)
   -- If a regular input, return word id, otherwise a table with features.
-  local inputs = self.sourceInput[t]
+  local inputs = (t and self.sourceInput[t]) or self.sourceInput:t()
 
   if #self.sourceInputFeatures > 0 then
     inputs = { inputs }

--- a/onmt/modules/CudnnEncoder.lua
+++ b/onmt/modules/CudnnEncoder.lua
@@ -74,6 +74,22 @@ function CudnnEncoder:resetPreallocation()
   self.rnn.gradCellOutput = torch.Tensor()
 end
 
+function CudnnEncoder:toNN()
+  local rnn
+
+  if self.rnn.mode == 'CUDNN_GRU' then
+    rnn = onmt.GRU(self.rnn.numLayers, self.rnn.inputSize, self.rnn.hiddenSize, self.rnn.dropout)
+  elseif self.rnn.mode == 'CUDNN_LSTM' then
+    rnn = onmt.LSTM(self.rnn.numLayers, self.rnn.inputSize, self.rnn.hiddenSize, self.rnn.dropout)
+  else
+    error('unsupported ' .. self.rnn.mode .. ' CuDNN mode')
+  end
+
+  rnn:setParameters(self.rnn:weights(), self.rnn:biases())
+
+  return onmt.Encoder(self.inputNetwork, rnn)
+end
+
 --[[Compute the context representation of an input.
 
 Parameters:

--- a/onmt/modules/CudnnEncoder.lua
+++ b/onmt/modules/CudnnEncoder.lua
@@ -1,0 +1,134 @@
+--[[ CudnnEncoder is a unidirectional/bidirectional Encoder used for the source language
+  using CuDNN RNN implementation
+
+    h_1 => h_2 => h_3 => ... => h_n
+     |      |      |             |
+     .      .      .             .
+     |      |      |             |
+    h_1 => h_2 => h_3 => ... => h_n
+     |      |      |             |
+     |      |      |             |
+    x_1    x_2    x_3           x_n
+
+--]]
+local CudnnEncoder, parent = torch.class('onmt.CudnnEncoder', 'nn.Container')
+
+--[[ Construct an encoder layer.
+
+Parameters:
+
+  * `inputNetwork` - input module
+  * `rnnClass` - CuDNN recurrent module class
+  * `layers` - number of layers
+  * `inputSize` - input dimension
+  * `rnnSize` - RNN hidden dimension
+  * `dropout` - dropout value
+]]
+function CudnnEncoder:__init(inputNetwork, rnnClass, layers, inputSize, rnnSize, dropout)
+  parent.__init(self)
+
+  self.rnn = rnnClass(inputSize, rnnSize, layers, false, dropout, false)
+  self.inputNetwork = inputNetwork
+
+  self.net = nn.Sequential()
+    :add(self.inputNetwork)
+    :add(nn.Transpose({1, 2})) -- By default, batch is second in CuDNN.
+    :add(self.rnn)
+
+  self:add(self.net)
+
+  self:resetPreallocation()
+end
+
+--[[ Return a new CudnnEncoder using the serialized data `pretrained`. ]]
+function CudnnEncoder.load(pretrained)
+  local self = torch.factory('onmt.CudnnEncoder')()
+
+  parent.__init(self)
+
+  self.net = pretrained.modules[1]
+  self.inputNetwork = self.net:get(1)
+  self.rnn = self.net:get(3)
+
+  self.rnn:resetDropoutDescriptor()
+  self.rnn:resetRNNDescriptor()
+  self.rnn:resetIODescriptors()
+
+  self:add(self.net)
+
+  self:resetPreallocation()
+
+  return self
+end
+
+--[[ Return data to serialize. ]]
+function CudnnEncoder:serialize()
+  return {
+    name = 'CudnnEncoder',
+    modules = self.modules
+  }
+end
+
+function CudnnEncoder:resetPreallocation()
+  self.rnn.gradHiddenOutput = torch.Tensor()
+  self.rnn.gradCellOutput = torch.Tensor()
+end
+
+--[[Compute the context representation of an input.
+
+Parameters:
+
+  * `batch` - as defined in batch.lua.
+
+Returns:
+
+  1. - final hidden states
+  2. - context matrix H
+
+--]]
+function CudnnEncoder:forward(batch)
+  self.inputs = batch:getSourceInput()
+
+  local context = self.net:forward(self.inputs):transpose(1, 2)
+
+  local states = {}
+
+  for i = 1, self.rnn.numLayers do
+    if self.rnn.mode == 'CUDNN_LSTM' then
+      table.insert(states, self.rnn.cellOutput[i])
+    end
+    table.insert(states, self.rnn.hiddenOutput[i])
+  end
+
+  return states, context
+end
+
+--[[ Backward pass (only called during training)
+
+Parameters:
+
+  * `batch` - must be same as for forward
+  * `gradStatesOutput` gradient of loss wrt last state - this can be null if states are not used
+  * `gradContextOutput` - gradient of loss wrt full context.
+
+Returns:
+
+  * `gradInputs` of input network.
+
+--]]
+function CudnnEncoder:backward(batch, gradStatesOutput, gradContextOutput)
+  self.rnn:resizeHidden(self.rnn.gradHiddenOutput)
+  self.rnn:resizeHidden(self.rnn.gradCellOutput)
+
+  -- gradStatesOutput is nil for instance when using in LanguageModel.
+  if gradStatesOutput then
+    for i = 1, self.rnn.numLayers do
+      self.rnn.gradHiddenOutput[i]:copy(gradStatesOutput[2 * i - 1]:narrow(2, 1, self.rnn.hiddenSize))
+      if not self.rnn.mode == 'CUDNN_GRU' then
+        self.rnn.gradCellOutput[i]:copy(gradStatesOutput[2 * i]:narrow(2, 1, self.rnn.hiddenSize))
+      end
+    end
+  end
+
+  return self.net:backward(self.inputs or batch:getSourceInput(), gradContextOutput:transpose(1, 2))
+end

--- a/onmt/modules/CudnnEncoder.lua
+++ b/onmt/modules/CudnnEncoder.lua
@@ -27,12 +27,11 @@ Parameters:
 function CudnnEncoder:__init(inputNetwork, rnnClass, layers, inputSize, rnnSize, dropout)
   parent.__init(self)
 
-  self.rnn = rnnClass(inputSize, rnnSize, layers, false, dropout, false)
+  self.rnn = rnnClass(inputSize, rnnSize, layers, true, dropout, false)
   self.inputNetwork = inputNetwork
 
   self.net = nn.Sequential()
     :add(self.inputNetwork)
-    :add(nn.Transpose({1, 2})) -- By default, batch is second in CuDNN.
     :add(self.rnn)
 
   self:add(self.net)
@@ -105,7 +104,7 @@ Returns:
 function CudnnEncoder:forward(batch)
   self.inputs = batch:getSourceInput()
 
-  local context = self.net:forward(self.inputs):transpose(1, 2)
+  local context = self.net:forward(self.inputs)
 
   local states = {}
 
@@ -146,5 +145,5 @@ function CudnnEncoder:backward(batch, gradStatesOutput, gradContextOutput)
     end
   end
 
-  return self.net:backward(self.inputs or batch:getSourceInput(), gradContextOutput:transpose(1, 2))
+  return self.net:backward(self.inputs or batch:getSourceInput(), gradContextOutput)
 end

--- a/onmt/modules/GRU.lua
+++ b/onmt/modules/GRU.lua
@@ -149,3 +149,29 @@ function GRU:_buildLayer(inputSize, hiddenSize)
 
   return nn.gModule(inputs, {nextH})
 end
+
+--[[ Set parameters as returned by CuDNN. ]]
+function GRU:setParameters(weights, biases)
+  local layer = 1
+  local i = 1
+
+  self.net:apply(function(m)
+    if torch.typename(m) == 'nn.Linear' then
+      if i > #weights[layer] then
+        i = 1
+        layer = layer + 1
+      end
+
+      for j = 1, 3 do
+        m.weight
+          :narrow(1, (j - 1) * self.outputSize + 1, self.outputSize)
+          :copy(weights[layer][i]:view(-1, self.outputSize))
+        m.bias
+          :narrow(1, (j - 1) * self.outputSize + 1, self.outputSize)
+          :copy(biases[layer][i])
+
+        i = i + 1
+      end
+    end
+  end)
+end

--- a/onmt/modules/init.lua
+++ b/onmt/modules/init.lua
@@ -3,6 +3,7 @@ onmt = onmt or {}
 require('onmt.modules.Sequencer')
 require('onmt.modules.Encoder')
 require('onmt.modules.BiEncoder')
+require('onmt.modules.CudnnEncoder')
 require('onmt.modules.Decoder')
 
 require('onmt.modules.Network')

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -37,6 +37,11 @@ function Translator:__init(args)
   self.models.encoder = onmt.Factory.loadEncoder(self.checkpoint.models.encoder)
   self.models.decoder = onmt.Factory.loadDecoder(self.checkpoint.models.decoder)
 
+  if torch.typename(self.models.encoder) == 'onmt.CudnnEncoder' then
+    _G.logger:warning('Translation with CuDNN models are not (yet) supported. Converting to NN...')
+    self.models.encoder = self.models.encoder:toNN()
+  end
+
   self.models.encoder:evaluate()
   self.models.decoder:evaluate()
 

--- a/onmt/utils/MemoryOptimizer.lua
+++ b/onmt/utils/MemoryOptimizer.lua
@@ -126,7 +126,7 @@ function MemoryOptimizer:__init(modules)
     elseif mod.modules then
       -- Otherwise, look in submodules instead.
       for i = 1, #mod.modules do
-        if mod.modules[i].net then
+        if torch.isTypeOf(mod, 'onmt.Sequencer') then
           self.modelDesc[name][i] = {}
           registerNet(self.modelDesc[name][i], mod.modules[i]:net(1), mod.modules[i].network)
         end

--- a/rocks/opennmt-scm-1.rockspec
+++ b/rocks/opennmt-scm-1.rockspec
@@ -37,6 +37,7 @@ build = {
     ["onmt.modules.BiEncoder"] = "onmt/modules/BiEncoder.lua",
     ["onmt.modules.Decoder"] = "onmt/modules/Decoder.lua",
     ["onmt.modules.Encoder"] = "onmt/modules/Encoder.lua",
+    ["onmt.modules.CudnnEncoder"] = "onmt/modules/CudnnEncoder.lua",
     ["onmt.modules.Network"] = "onmt/modules/Network.lua",
     ["onmt.modules.FeaturesEmbedding"] = "onmt/modules/FeaturesEmbedding.lua",
     ["onmt.modules.FeaturesGenerator"] = "onmt/modules/FeaturesGenerator.lua",

--- a/tools/release_model.lua
+++ b/tools/release_model.lua
@@ -76,7 +76,11 @@ local function main()
 
   _G.logger:info('Converting model...')
   checkpoint.info = nil
-  for _, model in pairs(checkpoint.models) do
+  for key, model in pairs(checkpoint.models) do
+    if model.name == 'CudnnEncoder' then
+      model = onmt.CudnnEncoder.load(model):toNN()
+      checkpoint.models[key] = model
+    end
     releaseModel(model)
   end
   _G.logger:info('... done.')


### PR DESCRIPTION
This PR adds a cuDNN-powered encoder that supports unidirectional LSTM and GRU. Conversion to `nn` is also provided for model release and translation.