### PR TITLE
Alternative decay strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add TensorBoard metrics visualisation with [Crayon](https://github.com/torrvision/crayon)
 * Add deep bidirectional encoder
 * Add pyramidal deep bidirectional encoder
+* Add alternative learning rate decay strategy for SGD training
 
 ### Fixes and improvements
 

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -92,12 +92,13 @@ function Checkpoint.loadFromCheckpoint(opt)
     -- Resume training from checkpoint
     if opt.continue then
       opt.optim = checkpoint.options.optim
-      opt.decay = checkpoint.options.decay
       opt.learning_rate_decay = checkpoint.options.learning_rate_decay
-      opt.min_learning_rate = checkpoint.options.min_learning_rate
-      opt.start_decay_ppl_delta = checkpoint.options.start_decay_ppl_delta
       opt.start_decay_at = checkpoint.options.start_decay_at
       opt.curriculum = checkpoint.options.curriculum
+
+      opt.decay = checkpoint.options.decay or opt.decay
+      opt.min_learning_rate = checkpoint.options.min_learning_rate or opt.min_learning_rate
+      opt.start_decay_ppl_delta = checkpoint.options.start_decay_ppl_delta or opt.start_decay_ppl_delta
 
       opt.learning_rate = checkpoint.info.learningRate
       opt.start_epoch = checkpoint.info.epoch

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -93,6 +93,7 @@ function Checkpoint.loadFromCheckpoint(opt)
     if opt.continue then
       opt.optim = checkpoint.options.optim
       opt.learning_rate_decay = checkpoint.options.learning_rate_decay
+      opt.min_learning_rate = checkpoint.options.min_learning_rate
       opt.start_decay_at = checkpoint.options.start_decay_at
       opt.curriculum = checkpoint.options.curriculum
 

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -95,6 +95,7 @@ function Checkpoint.loadFromCheckpoint(opt)
       opt.decay = checkpoint.options.decay
       opt.learning_rate_decay = checkpoint.options.learning_rate_decay
       opt.min_learning_rate = checkpoint.options.min_learning_rate
+      opt.start_decay_ppl_delta = checkpoint.options.start_decay_ppl_delta
       opt.start_decay_at = checkpoint.options.start_decay_at
       opt.curriculum = checkpoint.options.curriculum
 

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -92,6 +92,7 @@ function Checkpoint.loadFromCheckpoint(opt)
     -- Resume training from checkpoint
     if opt.continue then
       opt.optim = checkpoint.options.optim
+      opt.decay = checkpoint.options.decay
       opt.learning_rate_decay = checkpoint.options.learning_rate_decay
       opt.min_learning_rate = checkpoint.options.min_learning_rate
       opt.start_decay_at = checkpoint.options.start_decay_at

--- a/onmt/train/Optim.lua
+++ b/onmt/train/Optim.lua
@@ -67,9 +67,10 @@ local options = {
   {'-learning_rate_decay', 0.5 , [[Learning rate decay factor]]},
   {'-start_decay_at',      9   , [[With 'default' decay mode, start decay after this epoch]],
                                  {valid=onmt.utils.ExtendedCmdLine.isUInt()}},
+  {'-start_decay_ppl_delta', 0 , [[Start decay when validation perplexity improvement is lower than this value]]},
   {'-decay',          'default', [[When to apply learning rate decay.
-                                 'default': decay after each epoch past start_decay_at or as soon as the validation perplexity goes up,
-                                 'perplexity_only': only decay when validation perplexity goes up]],
+                                 'default': decay after each epoch past start_decay_at or as soon as the validation perplexity is not improving more than start_decay_ppl_delta,
+                                 'perplexity_only': only decay when validation perplexity is not improving more than start_decay_ppl_delta]],
                                  {enum={'default', 'perplexity_only'}}}
 }
 
@@ -159,7 +160,7 @@ function Optim:updateLearningRate(score, epoch)
     if self.valPerf[#self.valPerf] ~= nil and self.valPerf[#self.valPerf-1] ~= nil then
       local currPpl = self.valPerf[#self.valPerf]
       local prevPpl = self.valPerf[#self.valPerf-1]
-      if currPpl > prevPpl then
+      if prevPpl - currPpl < self.args.start_decay_ppl_delta then
         self.startDecay = true
         decayConditionMet = true
       end

--- a/onmt/train/Optim.lua
+++ b/onmt/train/Optim.lua
@@ -61,6 +61,7 @@ local options = {
   {'-learning_rate',       1   , [[Starting learning rate. If adagrad or adam is used,
                                       then this is the global learning rate. Recommended settings are: sgd = 1,
                                       adagrad = 0.1, adam = 0.0002]]},
+  {'-min_learning_rate',   0   , [[Do not continue the training past this learning rate]]},
   {'-max_grad_norm',       5   , [[If the norm of the gradient vector exceeds this renormalize it to have
                                        the norm equal to max_grad_norm]]},
   {'-learning_rate_decay', 0.5 , [[Decay learning rate by this much if (i) perplexity does not decrease
@@ -157,7 +158,11 @@ function Optim:updateLearningRate(score, epoch)
     if self.startDecay then
       self.args.learning_rate = self.args.learning_rate * self.args.learning_rate_decay
     end
+
+    return self.args.learning_rate >= self.args.min_learning_rate
   end
+
+  return true
 end
 
 function Optim:getLearningRate()

--- a/onmt/train/Trainer.lua
+++ b/onmt/train/Trainer.lua
@@ -299,9 +299,14 @@ function Trainer:train(model, optim, trainData, validData, dataset, info)
     if self.args.profiler then _G.logger:info('profile: %s', globalProfiler:log()) end
     _G.logger:info('Validation perplexity: %.2f', validPpl)
 
-    optim:updateLearningRate(validPpl, epoch)
+    local continue = optim:updateLearningRate(validPpl, epoch)
 
     checkpoint:saveEpoch(validPpl, epochState, true)
+
+    if not continue then
+      _G.logger:warning('Stopping training due to a too small learning rate value.')
+      break
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds an alternative and empirical learning rate decay strategy for SGD training:

* `-min_learning_rate` will stop the training when the learning rate is lower than this value
* `-start_decay_ppl_delta` will enable decaying when the validation perplexity is not improving by this much
* `-decay perplexity_only` will only decay the learning rate when the condition on the validation perplexity is met

The default behavior is unchanged.