### PR TITLE
Prevent IdvLoss in SampleDataset unless needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes and improvements
 
 * Fix translation with FP16 precision
+* Fix individual losses that were always computed when using random sampling
 
 ## [v0.5.0](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.5.0) (2017-03-06)
 

--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -54,11 +54,16 @@ function SampledDataset:__init(srcData, tgtData, opt)
 end
 
 function SampledDataset:checkModel(model)
-  if not model.returnIndividualLosses or model:returnIndividualLosses(true) == false then
+  if self:needIndividualLosses() and (not model.returnIndividualLosses or model:returnIndividualLosses(true) == false) then
     _G.logger:info('Current model does not support training with invididual losses; Sampling with individual loss will be disabled.')
     self.sample_w_ppl = false
     self.samplingProb = torch.ones(#self.src)
     self.ppl = nil
+  else
+    _G.logger:info('Current sampling does not require individual loss')
+    if model.returnIndividualLosses then
+      model:returnIndividualLosses(false)
+    end
   end
 end
 


### PR DESCRIPTION
When -sample option is used (random sampling of train instances) during training, individual losses are always calculated even if it is not needed.
This hotfix will enable IdvLoss only when it is needed thereby speeding up the training with random sampling.
