### PR TITLE
Support padded source batches during training

### DIFF
--- a/onmt/Seq2Seq.lua
+++ b/onmt/Seq2Seq.lua
@@ -88,8 +88,8 @@ function Seq2Seq:getOutput(batch)
 end
 
 function Seq2Seq:maskPadding(batch)
-  self.models.encoder:maskPadding()
   if self.args.uneven_batches then
+    self.models.encoder:maskPadding()
     if batch.uneven then
       self.models.decoder:maskPadding(batch.sourceSize, batch.sourceLength)
     else
@@ -105,13 +105,7 @@ function Seq2Seq:forwardComputeLoss(batch)
 end
 
 function Seq2Seq:trainNetwork(batch, dryRun)
-  if self.args.uneven_batches then
-    if batch.uneven then
-      self.models.decoder:maskPadding(batch.sourceSize, batch.sourceLength)
-    else
-      self.models.decoder:maskPadding()
-    end
-  end
+  self:maskPadding(batch)
 
   local encStates, context = self.models.encoder:forward(batch)
 

--- a/onmt/data/Batch.lua
+++ b/onmt/data/Batch.lua
@@ -4,7 +4,6 @@
 local function getLength(seq, ignore)
   local sizes = torch.IntTensor(#seq):zero()
   local max = 0
-  local sum = 0
   local uneven = false
 
   for i = 1, #seq do
@@ -18,10 +17,9 @@ local function getLength(seq, ignore)
       end
       max = len
     end
-    sum = sum + len
     sizes[i] = len
   end
-  return max, sizes, sum, uneven
+  return max, sizes, uneven
 end
 
 --[[ Data management and batch creation.
@@ -73,7 +71,7 @@ function Batch:__init(src, srcFeatures, tgt, tgtFeatures)
 
   self.size = #src
 
-  self.sourceLength, self.sourceSize, _, self.uneven = getLength(src)
+  self.sourceLength, self.sourceSize, self.uneven = getLength(src)
 
   local sourceSeq = torch.LongTensor(self.sourceLength, self.size):fill(onmt.Constants.PAD)
   self.sourceInput = sourceSeq:clone()

--- a/onmt/data/Batch.lua
+++ b/onmt/data/Batch.lua
@@ -5,17 +5,23 @@ local function getLength(seq, ignore)
   local sizes = torch.IntTensor(#seq):zero()
   local max = 0
   local sum = 0
+  local uneven = false
 
   for i = 1, #seq do
     local len = seq[i]:size(1)
     if ignore ~= nil then
       len = len - ignore
     end
-    max = math.max(max, len)
+    if max == 0 or len > max then
+      if max ~= 0 then
+        uneven = true
+      end
+      max = len
+    end
     sum = sum + len
     sizes[i] = len
   end
-  return max, sizes, sum
+  return max, sizes, sum, uneven
 end
 
 --[[ Data management and batch creation.
@@ -67,7 +73,7 @@ function Batch:__init(src, srcFeatures, tgt, tgtFeatures)
 
   self.size = #src
 
-  self.sourceLength, self.sourceSize = getLength(src)
+  self.sourceLength, self.sourceSize, _, self.uneven = getLength(src)
 
   local sourceSeq = torch.LongTensor(self.sourceLength, self.size):fill(onmt.Constants.PAD)
   self.sourceInput = sourceSeq:clone()

--- a/onmt/data/Dataset.lua
+++ b/onmt/data/Dataset.lua
@@ -23,30 +23,39 @@ function Dataset:setBatchSize(maxBatchSize, uneven_batches)
   self.maxSourceLength = 0
   self.maxTargetLength = 0
 
+  local batchesCapacity = 0
+  local batchesOccupation = 0
+
   -- Prepares batches in terms of range within self.src and self.tgt.
   local offset = 0
   local batchSize = 1
-  local sourceLength = 0
+  -- total size of sentences in current batch
+  local totalBatchSize = 0
+  local maxSourceLength = 0
   local targetLength = 0
 
   for i = 1, #self.src do
     -- Set up the offsets to make same source size batches of the
     -- correct size.
+    local sourceLength = self.src[i]:size(1)
     if batchSize == maxBatchSize or i == 1 or
-        (not(uneven_batches) and self.src[i]:size(1) ~= sourceLength) then
+        (not(uneven_batches) and self.src[i]:size(1) ~= maxSourceLength) then
       if i > 1 then
+        batchesCapacity = batchesCapacity + batchSize * maxSourceLength
         table.insert(self.batchRange, { ["begin"] = offset, ["end"] = i - 1 })
       end
 
       offset = i
       batchSize = 1
-      sourceLength = self.src[i]:size(1)
       targetLength = 0
+      maxSourceLength = 0
     else
       batchSize = batchSize + 1
     end
+    batchesOccupation = batchesOccupation + sourceLength
+    maxSourceLength = math.max(maxSourceLength, sourceLength)
 
-    self.maxSourceLength = math.max(self.maxSourceLength, self.src[i]:size(1))
+    self.maxSourceLength = math.max(self.maxSourceLength, sourceLength)
 
     if self.tgt ~= nil then
       -- Target contains <s> and </s>.
@@ -57,7 +66,7 @@ function Dataset:setBatchSize(maxBatchSize, uneven_batches)
   end
   -- Catch last batch.
   table.insert(self.batchRange, { ["begin"] = offset, ["end"] = #self.src })
-  return #self.batchRange
+  return #self.batchRange, batchesOccupation/batchesCapacity
 end
 
 --[[ Return number of batches. ]]

--- a/onmt/data/Dataset.lua
+++ b/onmt/data/Dataset.lua
@@ -15,8 +15,9 @@ function Dataset:__init(srcData, tgtData)
   end
 end
 
---[[ Setup up the training data to respect `maxBatchSize`. ]]
-function Dataset:setBatchSize(maxBatchSize)
+--[[ Setup up the training data to respect `maxBatchSize`.
+     If uneven_batches - then build up batches with different lengths ]]
+function Dataset:setBatchSize(maxBatchSize, uneven_batches)
 
   self.batchRange = {}
   self.maxSourceLength = 0
@@ -31,7 +32,8 @@ function Dataset:setBatchSize(maxBatchSize)
   for i = 1, #self.src do
     -- Set up the offsets to make same source size batches of the
     -- correct size.
-    if batchSize == maxBatchSize or self.src[i]:size(1) ~= sourceLength then
+    if batchSize == maxBatchSize or
+        not(not uneven_batches and self.src[i]:size(1) ~= sourceLength) then
       if i > 1 then
         table.insert(self.batchRange, { ["begin"] = offset, ["end"] = i - 1 })
       end
@@ -55,6 +57,7 @@ function Dataset:setBatchSize(maxBatchSize)
   end
   -- Catch last batch.
   table.insert(self.batchRange, { ["begin"] = offset, ["end"] = #self.src })
+  return #self.batchRange
 end
 
 --[[ Return number of batches. ]]

--- a/onmt/data/Dataset.lua
+++ b/onmt/data/Dataset.lua
@@ -62,7 +62,9 @@ function Dataset:setBatchSize(maxBatchSize, uneven_batches)
       self.maxTargetLength = math.max(self.maxTargetLength, targetSeqLength)
     end
   end
+
   -- Catch last batch.
+  batchesCapacity = batchesCapacity + batchSize * maxSourceLength
   table.insert(self.batchRange, { ["begin"] = offset, ["end"] = #self.src })
   return #self.batchRange, batchesOccupation/batchesCapacity
 end

--- a/onmt/data/Dataset.lua
+++ b/onmt/data/Dataset.lua
@@ -29,8 +29,6 @@ function Dataset:setBatchSize(maxBatchSize, uneven_batches)
   -- Prepares batches in terms of range within self.src and self.tgt.
   local offset = 0
   local batchSize = 1
-  -- total size of sentences in current batch
-  local totalBatchSize = 0
   local maxSourceLength = 0
   local targetLength = 0
 

--- a/onmt/data/Dataset.lua
+++ b/onmt/data/Dataset.lua
@@ -32,8 +32,8 @@ function Dataset:setBatchSize(maxBatchSize, uneven_batches)
   for i = 1, #self.src do
     -- Set up the offsets to make same source size batches of the
     -- correct size.
-    if batchSize == maxBatchSize or
-        not(not uneven_batches and self.src[i]:size(1) ~= sourceLength) then
+    if batchSize == maxBatchSize or i == 1 or
+        (not(uneven_batches) and self.src[i]:size(1) ~= sourceLength) then
       if i > 1 then
         table.insert(self.batchRange, { ["begin"] = offset, ["end"] = i - 1 })
       end

--- a/onmt/data/Preprocessor.lua
+++ b/onmt/data/Preprocessor.lua
@@ -55,6 +55,8 @@ local monotextOptions = {
 
 local commonOptions = {
   {'-features_vocabs_prefix', '',      [[Path prefix to existing features vocabularies.]]},
+  {'-sort',                   1,       [[If 1, sort the sentences by size.]],
+                                       { valid=onmt.utils.ExtendedCmdLine.isInt(0,1)} },
   {'-shuffle',                1,       [[If 1, shuffle data.]],
                                        { valid=onmt.utils.ExtendedCmdLine.isInt(0,1)} }
 }
@@ -165,9 +167,11 @@ function Preprocessor:makeBilingualData(srcFile, tgtFile, srcDicts, tgtDicts, is
     reorderData(perm)
   end
 
-  _G.logger:info('... sorting sentences by size')
-  local _, perm = torch.sort(vecToTensor(sizes))
-  reorderData(perm)
+  if self.args.sort == 1 then
+    _G.logger:info('... sorting sentences by size')
+    local _, perm = torch.sort(vecToTensor(sizes))
+    reorderData(perm)
+  end
 
   _G.logger:info('Prepared ' .. #src .. ' sentences (' .. ignored
                    .. ' ignored due to source length > ' .. self.args.src_seq_length
@@ -239,9 +243,11 @@ function Preprocessor:makeMonolingualData(file, dicts, isValid)
     reorderData(perm)
   end
 
-  _G.logger:info('... sorting sentences by size')
-  local _, perm = torch.sort(vecToTensor(sizes))
-  reorderData(perm)
+  if self.args.sort == 1 then
+    _G.logger:info('... sorting sentences by size')
+    local _, perm = torch.sort(vecToTensor(sizes))
+    reorderData(perm)
+  end
 
   _G.logger:info('Prepared ' .. #dataset .. ' sentences (' .. ignored
                    .. ' ignored due to length > ' .. self.args.seq_length .. ')')

--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -229,8 +229,9 @@ function SampledDataset:setLoss(batchIdx, loss)
 end
 
 --[[ Setup up the training data to respect `maxBatchSize`. ]]
-function SampledDataset:setBatchSize(maxBatchSize)
+function SampledDataset:setBatchSize(maxBatchSize, uneven_batches)
   self.maxBatchSize = maxBatchSize
+  self.uneven_batches = uneven_batches
   self.maxSourceLength = 0
   self.maxTargetLength = 0
 

--- a/onmt/modules/Decoder.lua
+++ b/onmt/modules/Decoder.lua
@@ -169,7 +169,7 @@ end
 --]]
 function Decoder:maskPadding(sourceSizes, sourceLength)
 
-  function substituteSoftmax(module)
+  local function substituteSoftmax(module)
     if module.name == 'softmaxAttn' then
       local mod
       if sourceSizes ~= nil then

--- a/onmt/modules/Decoder.lua
+++ b/onmt/modules/Decoder.lua
@@ -196,20 +196,18 @@ function Decoder:maskPadding(sourceSizes, sourceLength)
   end
   self.decoderAttn:replace(substituteSoftmax)
 
-  if self.train then
-    if not self.decoderAttnClones then
-      self.decoderAttnClones = {}
+  if not self.decoderAttnClones then
+    self.decoderAttnClones = {}
+  end
+  for t = 1, #self.networkClones do
+    if not self.decoderAttnClones[t] then
+      self:net(t):apply(function (layer)
+        if layer.name == 'decoderAttn' then
+          self.decoderAttnClones[t] = layer
+        end
+      end)
     end
-    for t = 1, #self.networkClones do
-      if not self.decoderAttnClones[t] then
-        self:net(t):apply(function (layer)
-          if layer.name == 'decoderAttn' then
-            self.decoderAttnClones[t] = layer
-          end
-        end)
-      end
-      self.decoderAttnClones[t]:replace(substituteSoftmax)
-    end
+    self.decoderAttnClones[t]:replace(substituteSoftmax)
   end
 end
 

--- a/onmt/train/Optim.lua
+++ b/onmt/train/Optim.lua
@@ -56,6 +56,7 @@ local Optim = torch.class('Optim')
 local options = {
   {'-max_batch_size',     64   , [[Maximum batch size]],
                                  {valid=onmt.utils.ExtendedCmdLine.isUInt()}},
+  {'-uneven_batches',     false, [[If true, batches are filled up to max_batch_size even if they have different sizes.]]},
   {'-optim',              'sgd', [[Optimization method.]],
                                  {enum={'sgd', 'adagrad', 'adadelta', 'adam'}}},
   {'-learning_rate',       1   , [[Starting learning rate. If adagrad or adam is used,

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -167,7 +167,7 @@ function Translator:translateBatch(batch)
   -- Compute gold score.
   local goldScore
   if batch.targetInput ~= nil then
-    if batch.size > 1 then
+    if batch.uneven then
       self.models.decoder:maskPadding(batch.sourceSize, batch.sourceLength)
     end
     goldScore = self.models.decoder:computeScore(batch, encStates, context)

--- a/onmt/utils/Memory.lua
+++ b/onmt/utils/Memory.lua
@@ -33,10 +33,11 @@ function Memory.optimize(model, batch, verbose)
   local memoryOptimizer = onmt.utils.MemoryOptimizer.new(model.models)
 
   -- Batch of one single word since we optimize the first clone.
-  local realSizes = { sourceLength = batch.sourceLength, targetLength = batch.targetLength }
+  local realSizes = { sourceLength = batch.sourceLength, targetLength = batch.targetLength, uneven = batch.uneven }
 
   batch.sourceLength = 1
   batch.targetLength = 1
+  batch.uneven = false
 
   model:trainNetwork(batch, true)
 
@@ -50,6 +51,7 @@ function Memory.optimize(model, batch, verbose)
   -- Restore batch to be transparent for the calling code.
   batch.sourceLength = realSizes.sourceLength
   batch.targetLength = realSizes.targetLength
+  batch.uneven = realSizes.uneven
 end
 
 return Memory

--- a/train.lua
+++ b/train.lua
@@ -76,7 +76,7 @@ local function main()
   end
   local validData = onmt.data.Dataset.new(dataset.valid.src, dataset.valid.tgt)
 
-  local nTrainBatch = trainData:setBatchSize(opt.max_batch_size, opt.uneven_batches)
+  local nTrainBatch, batchUsage = trainData:setBatchSize(opt.max_batch_size, opt.uneven_batches)
   validData:setBatchSize(opt.max_batch_size, opt.uneven_batches)
 
   if dataset.dataType == 'bitext' then
@@ -96,7 +96,8 @@ local function main()
     typeBatch = "(uneven)"
   end
   local avgBatchSize = #trainData.src/nTrainBatch
-  _G.logger:info(' * %d batches, maximum size: %d %s, avg size: %f', nTrainBatch, opt.max_batch_size, typeBatch, avgBatchSize)
+  _G.logger:info(' * %d batches, maximum size: %d %s, avg size: %f, batch Usage: %d%%',
+                    nTrainBatch, opt.max_batch_size, typeBatch, avgBatchSize, math.ceil(batchUsage*1000)/10)
 
   _G.logger:info('Building model...')
 

--- a/train.lua
+++ b/train.lua
@@ -96,7 +96,7 @@ local function main()
     typeBatch = "(uneven)"
   end
   local avgBatchSize = #trainData.src/nTrainBatch
-  _G.logger:info(' * %d batches, max size: %d %s, avg size: %f, batch Usage: %d%%',
+  _G.logger:info(' * %d batches, max size: %d %s, avg size: %f, capacity: %d%%',
                     nTrainBatch, opt.max_batch_size, typeBatch, avgBatchSize, math.ceil(batchUsage*1000)/10)
 
   _G.logger:info('Building model...')

--- a/train.lua
+++ b/train.lua
@@ -76,8 +76,8 @@ local function main()
   end
   local validData = onmt.data.Dataset.new(dataset.valid.src, dataset.valid.tgt)
 
-  trainData:setBatchSize(opt.max_batch_size)
-  validData:setBatchSize(opt.max_batch_size)
+  local nTrainBatch = trainData:setBatchSize(opt.max_batch_size, opt.uneven_batches)
+  validData:setBatchSize(opt.max_batch_size, opt.uneven_batches)
 
   if dataset.dataType == 'bitext' then
     _G.logger:info(' * vocabulary size: source = %d; target = %d',
@@ -91,7 +91,11 @@ local function main()
   _G.logger:info(' * maximum sequence length: source = %d; target = %d',
                  trainData.maxSourceLength, trainData.maxTargetLength)
   _G.logger:info(' * number of training sentences: %d', #trainData.src)
-  _G.logger:info(' * maximum batch size: %d', opt.max_batch_size)
+  local typeBatch = "(even)"
+  if opt.uneven_batches then
+    typeBatch = "(uneven)"
+  end
+  _G.logger:info(' * %d batches, maximum size: %d %s', nTrainBatch, opt.max_batch_size, typeBatch)
 
   _G.logger:info('Building model...')
 

--- a/train.lua
+++ b/train.lua
@@ -95,7 +95,8 @@ local function main()
   if opt.uneven_batches then
     typeBatch = "(uneven)"
   end
-  _G.logger:info(' * %d batches, maximum size: %d %s', nTrainBatch, opt.max_batch_size, typeBatch)
+  local avgBatchSize = #trainData.src/nTrainBatch
+  _G.logger:info(' * %d batches, maximum size: %d %s, avg size: %f', nTrainBatch, opt.max_batch_size, typeBatch, avgBatchSize)
 
   _G.logger:info('Building model...')
 

--- a/train.lua
+++ b/train.lua
@@ -96,7 +96,7 @@ local function main()
     typeBatch = "(uneven)"
   end
   local avgBatchSize = #trainData.src/nTrainBatch
-  _G.logger:info(' * %d batches, maximum size: %d %s, avg size: %f, batch Usage: %d%%',
+  _G.logger:info(' * %d batches, max size: %d %s, avg size: %f, batch Usage: %d%%',
                     nTrainBatch, opt.max_batch_size, typeBatch, avgBatchSize, math.ceil(batchUsage*1000)/10)
 
   _G.logger:info('Building model...')


### PR DESCRIPTION
new options - useful for very long sequences (summarization, asr) or potentially for translation.

In preprocess, possibility not to sort sentences by length
* `-sort`: If 1, sort the sentences by size. [1]

In train, possibility to built up batches with uneven sentence length
* `-uneven_batches`: If true, batches are filled up to max_batch_size even if they have different sizes. [false]
