### PR TITLE
Fix SampledDataset for breaking changes from 49a6412

### DIFF
--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -173,8 +173,6 @@ function SampledDataset:sample()
   local maxSourceLength = -1
   for i = 1, #self.src do
     for j = 1, self.sampledCnt[i] do
-
---      if batchSize == self.maxBatchSize or self.src[i]:size(1) ~= sourceLength then
       local sourceLength = self.src[i]:size(1)
       if batchSize == self.maxBatchSize or offset == 1 or
          (not(self.uneven_batches) and self.src[i]:size(1) ~= maxSourceLength) then
@@ -212,7 +210,7 @@ function SampledDataset:sample()
   end
 
   _G.logger:info('Prepared ' .. #self.batchRange .. ' batches')
-  return #self.batchRange, batchesOccupation/batchesCapacity
+  return #self.batchRange, batchesOccupation / batchesCapacity
 end
 
 --[[ Get perplexity. ]]

--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -164,15 +164,22 @@ function SampledDataset:sample()
   _G.logger:info('Sampled ' .. self.sampled:size(1) .. ' instances')
 
   -- Prepares batches in terms of range within self.src and self.tgt.
+  local batchesCapacity = 0
+  local batchesOccupation = 0
   self.batchRange = {}
   local offset = 0
   local sampleCntBegin = 1
   local batchSize = 1
-  local sourceLength = -1
+  local maxSourceLength = -1
   for i = 1, #self.src do
     for j = 1, self.sampledCnt[i] do
-      if batchSize == self.maxBatchSize or self.src[i]:size(1) ~= sourceLength then
+
+--      if batchSize == self.maxBatchSize or self.src[i]:size(1) ~= sourceLength then
+      local sourceLength = self.src[i]:size(1)
+      if batchSize == self.maxBatchSize or offset == 1 or
+         (not(self.uneven_batches) and self.src[i]:size(1) ~= maxSourceLength) then
         if offset > 0 then
+          batchesCapacity = batchesCapacity + batchSize * maxSourceLength
           local batchEnd = (j == 1) and i - 1 or i
           local sampleCntEnd = (j == 1) and self.sampledCnt[i - 1] or j - 1
           table.insert(self.batchRange, {
@@ -185,14 +192,17 @@ function SampledDataset:sample()
         end
         offset = i
         batchSize = 1
-        sourceLength = self.src[i]:size(1)
+        maxSourceLength = -1
       else
         batchSize = batchSize + 1
       end
+      batchesOccupation = batchesOccupation + sourceLength
+      maxSourceLength = math.max(maxSourceLength, sourceLength)
     end
   end
   -- Catch last batch.
   if offset < #self.src then
+    batchesCapacity = batchesCapacity + batchSize * maxSourceLength
     table.insert(self.batchRange, {
       ["begin"] = offset,
       ["end"] = #self.src,
@@ -202,6 +212,7 @@ function SampledDataset:sample()
   end
 
   _G.logger:info('Prepared ' .. #self.batchRange .. ' batches')
+  return #self.batchRange, batchesOccupation/batchesCapacity
 end
 
 --[[ Get perplexity. ]]
@@ -244,7 +255,7 @@ function SampledDataset:setBatchSize(maxBatchSize, uneven_batches)
     end
   end
 
-  self:sample()
+  return self:sample()
 end
 
 --[[ Return number of sampled instances. ]]


### PR DESCRIPTION
Due to changes introduced in 49a6412 that support for padded source batches (uneven source lengths), using SampledDataset (-sample) crashes during training due to missing return values from setBatchSize(maxBatchSize, uneven_batches).

`/DEV/torch/install/bin/luajit: ./train.lua:98: attempt to perform arithmetic on local 'nTrainBatch' (a nil value)`

This hotfix adds the missing return values.
