### PR TITLE
Save and Restore RNG States

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix individual losses that were always computed when using random sampling
 * Allow to change the state of word embeddings optimization during a retraining
 * Check consistency of option settings when training from existing model
+* Save and Restore random number generator states in checkpoints
 
 ## [v0.5.3](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.5.3) (2017-03-30)
 

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -31,6 +31,7 @@ end
 function Checkpoint:save(filePath, info)
   info.learningRate = self.optim:getLearningRate()
   info.optimStates = self.optim:getStates()
+  info.rngStates = onmt.utils.Cuda.getRNGStates()
 
   local data = {
     models = {},
@@ -128,6 +129,7 @@ function Checkpoint.loadFromCheckpoint(opt)
 
       opt.learning_rate = checkpoint.info.learningRate
       opt.start_epoch = checkpoint.info.epoch
+      onmt.utils.Cuda.setRNGStates(checkpoint.info.rngStates)
       opt.start_iteration = checkpoint.info.iteration
 
       _G.logger:info('Resuming training from epoch ' .. opt.start_epoch

--- a/onmt/train/Checkpoint.lua
+++ b/onmt/train/Checkpoint.lua
@@ -129,7 +129,6 @@ function Checkpoint.loadFromCheckpoint(opt)
 
       opt.learning_rate = checkpoint.info.learningRate
       opt.start_epoch = checkpoint.info.epoch
-      onmt.utils.Cuda.setRNGStates(checkpoint.info.rngStates)
       opt.start_iteration = checkpoint.info.iteration
 
       _G.logger:info('Resuming training from epoch ' .. opt.start_epoch

--- a/onmt/train/Trainer.lua
+++ b/onmt/train/Trainer.lua
@@ -124,6 +124,11 @@ function Trainer:train(model, optim, trainData, validData, dataset, info)
     gradParams[idx] = thegradParams
   end)
 
+  if info then
+    -- if we had saved a previous rng state - restore it
+    onmt.utils.Cuda.setRNGStates(info.rngStates, true)
+  end
+
   local checkpoint = onmt.train.Checkpoint.new(self.options, model, optim, dataset.dicts)
 
   optim:setOptimStates(#params[1])

--- a/onmt/utils/Cuda.lua
+++ b/onmt/utils/Cuda.lua
@@ -89,25 +89,27 @@ end
 
 -- returns RNGState for CPU and enabled GPUs
 function Cuda.getRNGStates()
-  local rngstates = { torch.getRNGState() }
+  local rngStates = { torch.getRNGState() }
   for _,idx in ipairs(Cuda.gpuIds) do
-    table.insert(rngstates, cutorch.getRNGState(idx))
+    table.insert(rngStates, cutorch.getRNGState(idx))
   end
   return rngStates
 end
 
 -- set RNGState from saved state
-function Cuda.setRNGStates(rngStates)
+function Cuda.setRNGStates(rngStates, verbose)
   if not rngStates then
     return
   end
-  _G.logger:info("Resetting Random Number Generator states")
+  if verbose then
+    _G.logger:info("Resetting Random Number Generator states")
+  end
   torch.setRNGState(rngStates[1])
   if #rngStates-1 ~= #Cuda.gpuIds then
     _G.logger:warning('GPU count does not match for resetting Random Number Generator - skipping')
   end
   for idx = 2, #Cuda.gpuIds do
-    cutorch.getRNGState(rngStates[idx], idx-1)
+    cutorch.setRNGState(rngStates[idx], idx-1)
   end
 end
 

--- a/onmt/utils/Cuda.lua
+++ b/onmt/utils/Cuda.lua
@@ -108,7 +108,7 @@ function Cuda.setRNGStates(rngStates, verbose)
   if #rngStates-1 ~= #Cuda.gpuIds then
     _G.logger:warning('GPU count does not match for resetting Random Number Generator - skipping')
   end
-  for idx = 2, #Cuda.gpuIds do
+  for idx = 2, #rngStates do
     cutorch.setRNGState(rngStates[idx], idx-1)
   end
 end

--- a/onmt/utils/Cuda.lua
+++ b/onmt/utils/Cuda.lua
@@ -87,6 +87,30 @@ function Cuda.init(opt, masterGPU)
   end
 end
 
+-- returns RNGState for CPU and enabled GPUs
+function Cuda.getRNGStates()
+  local rngstates = { torch.getRNGState() }
+  for _,idx in ipairs(Cuda.gpuIds) do
+    table.insert(rngstates, cutorch.getRNGState(idx))
+  end
+  return rngStates
+end
+
+-- set RNGState from saved state
+function Cuda.setRNGStates(rngStates)
+  if not rngStates then
+    return
+  end
+  _G.logger:info("Resetting Random Number Generator states")
+  torch.setRNGState(rngStates[1])
+  if #rngStates-1 ~= #Cuda.gpuIds then
+    _G.logger:warning('GPU count does not match for resetting Random Number Generator - skipping')
+  end
+  for idx = 2, #Cuda.gpuIds do
+    cutorch.getRNGState(rngStates[idx], idx-1)
+  end
+end
+
 --[[
   Recursively move all supported objects in `obj` on the GPU.
   When using CPU only, converts to float instead of the default double.


### PR DESCRIPTION
when saving checkpoint - save also RNG States so that `train_from` starts from exactly the same state