### PR TITLE
Relocate dataset sampling to the beginning of each epoch

### DIFF
--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -86,15 +86,18 @@ function SampledDataset:needIndividualLosses()
 end
 
 --[[ Initiate sampling. ]]
-function SampledDataset:sample()
-  _G.logger:info('Sampling...')
+function SampledDataset:sample(logLevel)
+
+  logLevel = logLevel or 'INFO'
+
+  _G.logger:log('Sampling...', logLevel)
 
   -- Populate self.samplingProb with self.ppl if average ppl is below self.sample_w_ppl_init.
   if self.sample_w_ppl and not self.startedPplSampling then
     local avgPpl = torch.sum(self.ppl)
     avgPpl = avgPpl / self.ppl:size(1)
     if avgPpl < self.sample_w_ppl_init then
-      _G.logger:info('Beginning to sample with ppl as probability distribution...')
+      _G.logger:log('Beginning to sample with ppl as probability distribution...', logLevel)
       self.startedPplSampling = true
     end
   end
@@ -149,10 +152,10 @@ function SampledDataset:sample()
 
       threshold = mode + x * stdev
 
-      _G.logger:info('Sampler count: ' .. cnt)
-      _G.logger:info('Sampler mode: ' .. mode)
-      _G.logger:info('Sampler stdev: ' .. stdev)
-      _G.logger:info('Sampler threshold: ' .. threshold)
+      _G.logger:log('Sampler count: ' .. cnt, logLevel)
+      _G.logger:log('Sampler mode: ' .. mode, logLevel)
+      _G.logger:log('Sampler stdev: ' .. stdev, logLevel)
+      _G.logger:log('Sampler threshold: ' .. threshold, logLevel)
     end
 
     for i = 1, self.ppl:size(1) do
@@ -166,7 +169,7 @@ function SampledDataset:sample()
   end
 
   local sampler = onmt.data.AliasMultinomial.new(self.samplingProb)
-  _G.logger:info('Created sampler...')
+  _G.logger:log('Created sampler...', logLevel)
   self.sampled = torch.LongTensor(self.samplingSize)
   self.sampled = sampler:batchdraw(self.sampled)
 
@@ -175,7 +178,7 @@ function SampledDataset:sample()
     self.sampledCnt[self.sampled[i]] = self.sampledCnt[self.sampled[i]] + 1
   end
 
-  _G.logger:info('Sampled ' .. self.sampled:size(1) .. ' instances')
+  _G.logger:log('Sampled ' .. self.sampled:size(1) .. ' instances', logLevel)
 
   -- Prepares batches in terms of range within self.src and self.tgt.
   local batchesCapacity = 0
@@ -223,7 +226,7 @@ function SampledDataset:sample()
     })
   end
 
-  _G.logger:info('Prepared ' .. #self.batchRange .. ' batches')
+  _G.logger:log('Prepared ' .. #self.batchRange .. ' batches', logLevel)
   return #self.batchRange, batchesOccupation / batchesCapacity
 end
 
@@ -267,7 +270,7 @@ function SampledDataset:setBatchSize(maxBatchSize, uneven_batches)
     end
   end
 
-  return self:sample()
+  return self:sample('DEBUG')
 end
 
 --[[ Return number of sampled instances. ]]

--- a/onmt/train/Trainer.lua
+++ b/onmt/train/Trainer.lua
@@ -138,6 +138,10 @@ function Trainer:train(model, optim, trainData, validData, dataset, info)
 
     local startI = self.args.start_iteration
 
+    if trainData.sample then
+      trainData:sample()
+    end
+
     local numIterations = trainData:batchCount()
     -- In parallel mode, number of iterations is reduced to reflect larger batch size.
     if onmt.utils.Parallel.count > 1 and not self.args.async_parallel then
@@ -314,10 +318,6 @@ function Trainer:train(model, optim, trainData, validData, dataset, info)
 
     if needLog then
       epochState:log(numIterations)
-    end
-
-    if trainData.sample then
-      trainData:sample()
     end
 
     return epochState, epochProfiler:dump()


### PR DESCRIPTION
Per request of Jean S., I am adjusting the dataset sampling from the end of epoch to the beginning.

Reasons are two fold:
 1. it is strange to see the sampling before the network initialization and at the end of epoch.
 2. saving epoch state will have exact sampler state

For 1, sampling log messages are logged at debug level when called from setbatchSize() and at info level otherwise.
