### PR TITLE
Change granularity of bin for calculating mode for ppl-based sampling

### DIFF
--- a/onmt/data/SampledDataset.lua
+++ b/onmt/data/SampledDataset.lua
@@ -118,7 +118,7 @@ function SampledDataset:sample()
       local x = math.abs(self.sample_w_ppl_max)
 
       -- Find mode.
-      local pplRounded = torch.round(self.ppl)
+      local pplRounded = torch.round(self.ppl * 100) / 100 -- keep up to the second decimal point
       local bin = {}
       for i = 1, pplRounded:size(1) do
         if self.ppl[i] ~=  self.sample_w_ppl_init then


### PR DESCRIPTION
Mode is calculated from binned counts of perplexity scores.
Bin granularity is changed from integer (no decimal point) to the second decimal point to allow mode to be more accurate.

More accurate mode value will allow better estimation of max ppl threshold.
