### PR TITLE
Fix uneven batch condition

### DIFF
--- a/onmt/data/Batch.lua
+++ b/onmt/data/Batch.lua
@@ -12,10 +12,10 @@ local function getLength(seq, ignore)
       len = len - ignore
     end
     if max == 0 or len > max then
-      if max ~= 0 then
-        uneven = true
-      end
       max = len
+    end
+    if max ~= len then
+      uneven = true
     end
     sizes[i] = len
   end


### PR DESCRIPTION
The condition did not work when the first sequence is the longest one.