### PR TITLE
Fix DBiEncoder and PDBiEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes and improvements
 
+* Improve correctness of `DBiEncoder` and `PDBiEncoder` implementation
 * Fix translation error of models profiled during training
 
 ## [v0.6.0](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.6.0) (2017-04-07)

--- a/onmt/data/BatchTensor.lua
+++ b/onmt/data/BatchTensor.lua
@@ -3,15 +3,22 @@ local BatchTensor = torch.class('BatchTensor')
 --[[
   Take Batch x TimeStep x layer size tensors
 ]]
-function BatchTensor:__init(T)
-  self.t = T
-  self.sourceLength = T:size()[2]
-  self.sourceSize = torch.LongTensor(T:size()[1]):fill(self.sourceLength)
+function BatchTensor:__init(T, sizes)
   self.size = T:size()[1]
+  self.sourceLength = T:size()[2]
+
+  self.sourceSize = sizes or torch.LongTensor(self.size):fill(self.sourceLength)
+
+  self.sourceInput = T
+  self.sourceInputPadLeft = true
+
+  self.sourceInputRev = self.sourceInput
+    :index(2, torch.linspace(self.sourceLength, 1, self.sourceLength):long())
+  self.sourceInputRevPadLeft = false
 end
 
 function BatchTensor:getSourceInput(t)
-  return self.t:select(2,t)
+  return self.sourceInput:select(2, t)
 end
 
 return BatchTensor

--- a/onmt/modules/DBiEncoder.lua
+++ b/onmt/modules/DBiEncoder.lua
@@ -129,20 +129,22 @@ function DBiEncoder:forward(batch)
 end
 
 function DBiEncoder:backward(batch, gradStatesOutput, gradContextOutput)
+  local gradInputs
+
   for i = #self.layers, 1, -1 do
     local lrange_gradStatesOutput
     if gradStatesOutput then
       lrange_gradStatesOutput = gradStatesOutput[{}]
     end
-    local gradContextInput = self.layers[i]:backward(self.inputs[i], lrange_gradStatesOutput, gradContextOutput)
+    gradInputs = self.layers[i]:backward(self.inputs[i], lrange_gradStatesOutput, gradContextOutput)
     if i ~= 1 then
       gradContextOutput = onmt.utils.Tensor.reuseTensor(self.gradContextProto,
-                                              { batch.size, #gradContextInput, self.args.hiddenSize })
-      for t = 1, #gradContextInput do
-        gradContextOutput[{{},t,{}}]:copy(gradContextInput[t])
+                                              { batch.size, #gradInputs, self.args.hiddenSize })
+      for t = 1, #gradInputs do
+        gradContextOutput[{{},t,{}}]:copy(gradInputs[t])
       end
     end
   end
 
-  return gradContextOutput
+  return gradInputs
 end

--- a/onmt/modules/DBiEncoder.lua
+++ b/onmt/modules/DBiEncoder.lua
@@ -95,7 +95,9 @@ function DBiEncoder:resetPreallocation()
 end
 
 function DBiEncoder:maskPadding()
-  self.layers[1]:maskPadding()
+  for _, layer in ipairs(self.layers) do
+    layer:maskPadding()
+  end
 end
 
 function DBiEncoder:forward(batch)
@@ -115,7 +117,7 @@ function DBiEncoder:forward(batch)
   for i = 1,#self.layers do
     local layerStates, layerContext = self.layers[i]:forward(self.inputs[i])
     if i ~= #self.layers then
-      table.insert(self.inputs, onmt.data.BatchTensor.new(layerContext))
+      table.insert(self.inputs, onmt.data.BatchTensor.new(layerContext, batch.sourceSize))
     else
       context:copy(layerContext)
     end

--- a/onmt/modules/DBiEncoder.lua
+++ b/onmt/modules/DBiEncoder.lua
@@ -60,6 +60,7 @@ function DBiEncoder.load(pretrained)
 
   for i=1, #pretrained.layers do
     self.layers[i] = onmt.BiEncoder.load(pretrained.layers[i])
+    self:add(self.layers[i])
   end
 
   self.args = pretrained.args

--- a/onmt/modules/PDBiEncoder.lua
+++ b/onmt/modules/PDBiEncoder.lua
@@ -72,6 +72,7 @@ function PDBiEncoder.load(pretrained)
 
   for i=1, #pretrained.layers do
     self.layers[i] = onmt.BiEncoder.load(pretrained.layers[i])
+    self:add(self.layers[i])
   end
 
   self.args = pretrained.args


### PR DESCRIPTION
This PR fixes some issues related to new encoder variants:

* the returned `gradInputs` were not consistent with the existing `Encoder` and `BiEncoder`
* some fields were missing in `BatchTensor` to process it in both directions
* padding was partially masked in DBiEncoder because sequences lengths were not passed on to the bottom layers
* loaded layers were not added back to the `modules` list