### PR TITLE
[WIP] enable parallel training on CPU and or GPUs

### DIFF
--- a/onmt/utils/Cuda.lua
+++ b/onmt/utils/Cuda.lua
@@ -3,7 +3,8 @@ local ExtendedCmdLine = require('onmt.utils.ExtendedCmdLine')
 local Cuda = {
   fp16 = false,
   gpuIds = {},
-  activated = false
+  deviceIds = {},
+  cpuTraining = false
 }
 
 local options = {
@@ -32,58 +33,46 @@ function Cuda.declareOpts(cmd)
   cmd:setCmdLineOptions(options, 'Cuda')
 end
 
-function Cuda.init(opt, masterGPU)
-  for _, val in ipairs(onmt.utils.String.split(opt.gpuid, ',')) do
-    local id = tonumber(val)
-    assert(id ~= nil and id >= 0, 'invalid GPU identifier: ' .. val)
-    if id > 0 then
-      table.insert(Cuda.gpuIds, id)
-    end
-  end
-
-  Cuda.activated = #Cuda.gpuIds > 0
-
-  if Cuda.activated then
-    local _, err = pcall(function()
-      require('cutorch')
-      require('cunn')
-      Cuda.fp16 = opt.fp16
-
-      if masterGPU == nil then
-        masterGPU = 1
-
-        -- Validate GPU identifiers.
-        for i = 1, #Cuda.gpuIds do
-          assert(Cuda.gpuIds[i] <= cutorch.getDeviceCount(),
-                 'GPU ' .. Cuda.gpuIds[i] .. ' is requested but only '
-                   .. cutorch.getDeviceCount() .. ' GPUs are available')
+function Cuda.init(opt, deviceId)
+  if not deviceId then
+    local usedGpuIds = {}
+    for _, val in ipairs(onmt.utils.String.split(opt.gpuid, ',')) do
+      local id = tonumber(val)
+      if id > 0 and not usedGpuIds[id] then
+        if #Cuda.gpuIds == 0 then
+          require('cutorch')
         end
-
-        _G.logger:info('Using GPU(s): ' .. table.concat(Cuda.gpuIds, ', '))
-
-        if cutorch.isCachingAllocatorEnabled and cutorch.isCachingAllocatorEnabled() then
-          _G.logger:warning('The caching CUDA memory allocator is enabled. This allocator improves performance at the cost of a higher GPU memory usage. To optimize for memory, consider disabling it by setting the environment variable: THC_CACHING_ALLOCATOR=0')
-        end
-
-      end
-
-      cutorch.setDevice(Cuda.gpuIds[masterGPU])
-
-      if opt.seed then
+        table.insert(Cuda.gpuIds, id)
+        usedGpuIds[id] = true
+        cutorch.setDevice(id)
         cutorch.manualSeed(opt.seed)
-      end
-    end)
-
-    if err then
-      if opt.fallback_to_cpu then
-        _G.logger:warning('Falling back to CPU')
-        Cuda.activated = false
       else
-        error(err)
+        Cuda.cpuTraining = true
+      end
+      table.insert(Cuda.deviceIds, id)
+    end
+    if #Cuda.gpuIds > 0 then
+      _G.logger:info('Using GPU(s): ' .. table.concat(Cuda.gpuIds, ', '))
+      if cutorch.isCachingAllocatorEnabled and cutorch.isCachingAllocatorEnabled() then
+        _G.logger:warning('The caching CUDA memory allocator is enabled. This allocator improves performance at the cost of a higher GPU memory usage. To optimize for memory, consider disabling it by setting the environment variable: THC_CACHING_ALLOCATOR=0')
       end
     end
-    if Cuda.fp16 and not cutorch.hasHalf then
-      error("installed cutorch does not support half-tensor")
+    if Cuda.cpuTraining then
+      _G.logger:info('Using CPU')
+    end
+    Cuda.fp16 = opt.fp16
+    if Cuda.fp16 and (not cutorch or (cutorch and not cutorch.hasHalf) or Cuda.cpuTraining) then
+      error("fp16 requested but installed cutorch does not support half-tensor and/or cpu training")
+    end
+    -- by default master node is the first one
+    _G.threadDeviceId = Cuda.deviceIds[1]
+  else
+    _G.threadDeviceId = deviceId
+    if deviceId > 0 then
+      assert(Cuda.deviceIds[id] <= cutorch.getDeviceCount(),
+                 'GPU ' .. Cuda.deviceIds[id] .. ' is requested but only '
+                   .. cutorch.getDeviceCount() .. ' GPUs are available')
+      cutorch.setDevice(Cuda.deviceIds[id])
     end
   end
 end
@@ -122,7 +111,7 @@ end
 function Cuda.convert(obj)
   local objtype = torch.typename(obj)
   if objtype then
-    if Cuda.activated and obj.cuda ~= nil then
+    if _G.threadDeviceId > 0 and obj.cuda ~= nil then
       if objtype:find('torch%..*LongTensor') then
         return obj:type('torch.CudaLongTensor')
       elseif Cuda.fp16 then
@@ -130,7 +119,7 @@ function Cuda.convert(obj)
       else
         return obj:type('torch.CudaTensor')
       end
-    elseif not Cuda.activated and obj.float ~= nil then
+    elseif _G.threadDeviceId == 0 and obj.float ~= nil then
       -- Defaults to float instead of double.
       if objtype:find('torch%..*LongTensor') then
         return obj:type('torch.LongTensor')
@@ -154,22 +143,22 @@ end
   Do nothing otherwise.
 ]]
 function Cuda.synchronize()
-  if Cuda.activated then cutorch.synchronize() end
+  if _G.threadDevice > 0 then cutorch.synchronize() end
 end
 
 --[[
   Number of available GPU.
 ]]
-function Cuda.gpuCount()
-  return #Cuda.gpuIds
+function Cuda.replicaCount()
+  return #Cuda.deviceIds
 end
 
 --[[
   Free memory on the current GPU device.
 ]]
 function Cuda.freeMemory()
-  if Cuda.activated then
-    local freeMemory = cutorch.getMemoryUsage(cutorch.getDevice())
+  if _G.threadDevice > 0 then
+    local freeMemory = cutorch.getMemoryUsage(_G.threadDevice)
     return freeMemory
   end
   return 0

--- a/onmt/utils/Parallel.lua
+++ b/onmt/utils/Parallel.lua
@@ -12,10 +12,12 @@ local Parallel = {
 -- Synchronizes the current stream on dst device with src device. This is only
 -- necessary if we are not on the default stream
 local function waitForDevice(dst, src)
-   local stream = cutorch.getStream()
-   if stream ~= 0 then
+  if dst > 0 and src > 0 then
+    local stream = cutorch.getStream()
+    if stream ~= 0 then
       cutorch.streamWaitForMultiDevice(dst, stream, { [src] = {stream} })
-   end
+    end
+  end
 end
 
 function Parallel.getCounter()
@@ -27,47 +29,47 @@ function Parallel.gmutexId()
 end
 
 function Parallel.init(opt)
-  if onmt.utils.Cuda.activated then
-    Parallel.count = onmt.utils.Cuda.gpuCount()
-    Parallel.gradBuffer = onmt.utils.Cuda.convert(Parallel.gradBuffer)
-    Parallel._tds = require('tds')
+  Parallel.count = onmt.utils.Cuda.replicaCount()
+  Parallel.gradBuffer = onmt.utils.Cuda.convert(Parallel.gradBuffer)
+  Parallel._tds = require('tds')
 
-    if Parallel.count > 1 then
-      local globalLogger = _G.logger
-      local globalProfiler = _G.profiler
-      local threads = require('threads')
-      threads.Threads.serialization('threads.sharedserialize')
-      Parallel._gmutex = threads.Mutex()
-      Parallel._pool = threads.Threads(
-        Parallel.count,
-        function()
+  if Parallel.count > 1 then
+    local globalLogger = _G.logger
+    local globalProfiler = _G.profiler
+    local threads = require('threads')
+    threads.Threads.serialization('threads.sharedserialize')
+    Parallel._gmutex = threads.Mutex()
+    local deviceIds = onmt.utils.Cuda.deviceIds
+    Parallel._pool = threads.Threads(
+      Parallel.count,
+      function(threadid)
+        if deviceIds[threadid] > 0 then
           require('cunn')
           require('nngraph')
-          require('onmt.init')
-          _G.threads = require('threads')
-        end,
-        function(threadid)
-          _G.logger = globalLogger
-          _G.profiler = globalProfiler
-          onmt.utils.Cuda.init(opt, threadid)
         end
-      ) -- dedicate threads to GPUs
-      Parallel._pool:specific(true)
-    end
-
-    if Parallel.count > 1 and not opt.no_nccl and not opt.async_parallel then
-      -- check if we have nccl installed
-      local ret
-      ret, Parallel.usenccl = pcall(require, 'nccl')
-      if not ret then
-        _G.logger:warning("For improved efficiency with multiple GPUs, consider installing nccl")
-        Parallel.usenccl = nil
-      elseif os.getenv('CUDA_LAUNCH_BLOCKING') == '1' then
-        _G.logger:warning("CUDA_LAUNCH_BLOCKING set - cannot use nccl")
-        Parallel.usenccl = nil
+        require('onmt.init')
+        _G.threads = require('threads')
+      end,
+      function(threadid)
+        _G.logger = globalLogger
+        _G.profiler = globalProfiler
+        onmt.utils.Cuda.init(opt, deviceIds[threadid])
       end
-    end
+    ) -- dedicate threads to devices
+    Parallel._pool:specific(true)
+  end
 
+  if Parallel.count > 1 and #onmt.utils.Cuda.gpuIds > 0 and not opt.no_nccl then
+    -- check if we have nccl installed
+    local ret
+    ret, Parallel.usenccl = pcall(require, 'nccl')
+    if not ret then
+      _G.logger:warning("For improved efficiency with multiple GPUs, consider installing nccl")
+      Parallel.usenccl = nil
+    elseif os.getenv('CUDA_LAUNCH_BLOCKING') == '1' then
+      _G.logger:warning("CUDA_LAUNCH_BLOCKING set - cannot use nccl")
+      Parallel.usenccl = nil
+    end
   end
 end
 
@@ -98,10 +100,10 @@ function Parallel.accGradParams(gradParams, batches)
 
          -- Synchronize before and after copy to ensure that it doesn't overlap
          -- with this add or previous adds
-          waitForDevice(onmt.utils.Cuda.gpuIds[j], onmt.utils.Cuda.gpuIds[1])
+          waitForDevice(onmt.utils.Cuda.deviceIds[j], onmt.utils.Cuda.deviceIds[1])
           local remoteGrads = onmt.utils.Tensor.reuseTensor(Parallel.gradBuffer, gradParams[j][h]:size())
           remoteGrads:copy(gradParams[j][h])
-          waitForDevice(onmt.utils.Cuda.gpuIds[1], onmt.utils.Cuda.gpuIds[j])
+          waitForDevice(onmt.utils.Cuda.deviceIds[1], onmt.utils.Cuda.deviceIds[j])
           gradParams[1][h]:add(remoteGrads)
         else
           table.insert(inputs, gradParams[j][h])
@@ -144,7 +146,7 @@ function Parallel.syncParams(params)
         for h = 1, #params[1] do
           params[j][h]:copy(params[1][h])
         end
-        waitForDevice(onmt.utils.Cuda.gpuIds[j], onmt.utils.Cuda.gpuIds[1])
+        waitForDevice(onmt.utils.Cuda.deviceIds[j], onmt.utils.Cuda.deviceIds[1])
       end
     else
       for h = 1, #params[1] do


### PR DESCRIPTION
possibility to use CPU in parallel training (-gpuid 0,1) and to use several time the same devices (-gpuid 7,7)

probability we will need to deprecate/restrict `fallback_to_cpu` which meaningless in parallel context