### PR TITLE
Beamnorm fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Improve correctness of `DBiEncoder` and `PDBiEncoder` implementation
 * Fix translation error of models profiled during training
 * Fix error when using one-layer GRU
+* Fix incorrect coverage normalization formula during the beam search
 * Do not allow duplicate commandline options and do not print help on errors
 
 ## [v0.6.0](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.6.0) (2017-04-07)

--- a/onmt/translate/Beam.lua
+++ b/onmt/translate/Beam.lua
@@ -343,7 +343,7 @@ function Beam:_normalizeScores(scores)
 
   local function normalizeCoverage(ap)
     local beta = self._params.coverage_norm
-    local result = torch.cmin(ap, 1.0):log1p():sum(3):mul(beta)
+    local result = torch.cmin(ap, 1.0):log():sum(3):mul(beta)
     return result
   end
 

--- a/onmt/translate/Beam.lua
+++ b/onmt/translate/Beam.lua
@@ -350,8 +350,8 @@ function Beam:_normalizeScores(scores)
   local step = self._step
   local lengthPenalty = normalizeLength(step)
 
-  local attnProba = self._state[8]:view(self._remaining, scores:size(2), -1)
-  local coveragePenalty = normalizeCoverage(attnProba)
+  local cumAttnProba = self._state[8]:view(self._remaining, scores:size(2), -1)
+  local coveragePenalty = normalizeCoverage(cumAttnProba)
 
   if (scores:nDimension() > 2) then
     coveragePenalty =  coveragePenalty:expand(scores:size())


### PR DESCRIPTION
fix coverage penalty calculation: using `log1p` actually calculates `log(1+torch.cmin(ap,1.0))` - that does not have large negative values of original formula enforcing coverage