### PR TITLE
Optimize memory usage of network replicas

### DIFF
--- a/onmt/train/Trainer.lua
+++ b/onmt/train/Trainer.lua
@@ -114,7 +114,7 @@ function Trainer:__init(args, model, dicts, firstBatch)
     if self.params[idx] then
       _G.params, _G.gradParams = self.params[idx], self.gradParams[idx]
     else
-      _G.params, _G.gradParams = _G.model:getParams()
+      _G.params, _G.gradParams = _G.model:getParams(true)
     end
 
     return idx, _G.params, _G.gradParams


### PR DESCRIPTION
Network replicas called `getParameters` even though parameters are already flattened in a single storage.

@vince62s Related to #288, I would like you to test this PR (using `THC_CACHING_ALLOCATOR=0` if needed).