### PR TITLE
Add case segmenting in order to be able restore words like WiFi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * New option in preprocess to check that sizes of source and target are equal (for seqtagging)
 * Add `-pdbrnn_merge` option to define how to reduce the time dimension
+* Add option to segment mixed cased words
 
 ### Fixes and improvements
 

--- a/docs/options/learn_bpe.md
+++ b/docs/options/learn_bpe.md
@@ -12,6 +12,7 @@
 * `-size <string>` (default: `30000`)<br/>The number of merge operations to learn.
 * `-t [<boolean>]` (default: `false`)<br/>Tokenize the input with tokenizer, the same options as tokenize.lua, but only `-mode` is taken into account for BPE training.
 * `-mode <string>` (accepted: `conservative`, `aggressive`; default: `conservative`)<br/>Define how aggressive should the tokenization be. `aggressive` only keeps sequences of letters/numbers, `conservative` allows a mix of alphanumeric as in: "2,000", "E65", "soft-landing", etc.
+* `-segment_case [<boolean>]` (default: `false`)<br/>Segment case feature, splits AbC to Ab C to be able to restore case
 * `-lc [<boolean>]` (default: `false`)<br/>Lowercase the output from the tokenizer before learning BPE.
 * `-bpe_mode <string>` (accepted: `suffix`, `prefix`, `both`, `none`; default: `suffix`)<br/>Define the BPE mode. `prefix`: append `<w>` to the begining of each word to learn prefix-oriented pair statistics; `suffix`: append `</w>` to the end of each word to learn suffix-oriented pair statistics, as in the original Python script; `both`: `suffix` and `prefix`; `none`: no `suffix` nor `prefix`.
 * `-save_bpe <string>` (default: `''`)<br/>Path to save the output model.

--- a/docs/options/rest_server.md
+++ b/docs/options/rest_server.md
@@ -49,6 +49,7 @@
 * `-joiner <string>` (default: `￭`)<br/>Character used to annotate joiners.
 * `-joiner_new [<boolean>]` (default: `false`)<br/>In `-joiner_annotate` mode, `-joiner` is an independent token.
 * `-case_feature [<boolean>]` (default: `false`)<br/>Generate case feature.
+* `-segment_case [<boolean>]` (default: `false`)<br/>Segment case feature, splits AbC to Ab C to be able to restore case
 * `-bpe_model <string>` (default: `''`)<br/>Apply Byte Pair Encoding if the BPE model path is given. If the option is used, `-mode` will be overridden/set automatically if the BPE model specified by `-bpe_model` is learnt using `learn_bpe.lua`.
 * `-EOT_marker <string>` (default: `</w>`)<br/>Marker used to mark the end of token.
 * `-BOT_marker <string>` (default: `<w>`)<br/>Marker used to mark the beginning of token.

--- a/docs/options/tokenize.md
+++ b/docs/options/tokenize.md
@@ -14,6 +14,7 @@
 * `-joiner <string>` (default: `￭`)<br/>Character used to annotate joiners.
 * `-joiner_new [<boolean>]` (default: `false`)<br/>In `-joiner_annotate` mode, `-joiner` is an independent token.
 * `-case_feature [<boolean>]` (default: `false`)<br/>Generate case feature.
+* `-segment_case [<boolean>]` (default: `false`)<br/>Segment case feature, splits AbC to Ab C to be able to restore case
 * `-bpe_model <string>` (default: `''`)<br/>Apply Byte Pair Encoding if the BPE model path is given. If the option is used, `-mode` will be overridden/set automatically if the BPE model specified by `-bpe_model` is learnt using `learn_bpe.lua`.
 * `-EOT_marker <string>` (default: `</w>`)<br/>Marker used to mark the end of token.
 * `-BOT_marker <string>` (default: `<w>`)<br/>Marker used to mark the beginning of token.

--- a/docs/tools/tokenization.md
+++ b/docs/tools/tokenization.md
@@ -24,6 +24,14 @@ th tools/detokenize.lua OPTIONS < file.tok > file.detok
 * `￨` is the feature separator symbol. If such character is used in source text, it is replaced by its non presentation form `│`.
 * `￭` is the default joiner marker (generated in `-joiner_annotate marker` mode). If such character is used in source text, it is replaced by its non presentation form `■`
 
+## Mixed casing words
+`-segment_case` feature enables tokenizer to segment words in order to restore in the process of  detokenization correct casing for mixed casing words.
+Tokenizer with this option splits words into segments so all letters in every segment are either lowercased, or uppercased, or first letter is uppercases and rest are lowercased
+```text
+WiFi --> Wi￨C Fi￨C
+TVs --> Tv￨C s￨l
+```
+
 ## BPE
 
 OpenNMT's BPE module fully supports the [original BPE](https://github.com/rsennrich/subword-nmt) as default mode:

--- a/docs/tools/tokenization.md
+++ b/docs/tools/tokenization.md
@@ -28,7 +28,7 @@ th tools/detokenize.lua OPTIONS < file.tok > file.detok
 `-segment_case` feature enables tokenizer to segment words into subwords with one of 3 casing types (truecase ('House'), uppercase ('HOUSE') or lowercase ('house')), which helps  restore right casing during  detokenization. This feature is especially useful for texts with a signficant number of words with mixed casing ('WiFi' -> 'Wi' and 'Fi').
 ```text
 WiFi --> wi￨C fi￨C
-TVs --> tv￨C s￨l
+TVs --> tv￨U s￨L
 ```
 
 ## BPE

--- a/docs/tools/tokenization.md
+++ b/docs/tools/tokenization.md
@@ -25,8 +25,7 @@ th tools/detokenize.lua OPTIONS < file.tok > file.detok
 * `￭` is the default joiner marker (generated in `-joiner_annotate marker` mode). If such character is used in source text, it is replaced by its non presentation form `■`
 
 ## Mixed casing words
-`-segment_case` feature enables tokenizer to segment words in order to restore in the process of  detokenization correct casing for mixed casing words.
-Tokenizer with this option splits words into segments so all letters in every segment are either lowercased, or uppercased, or first letter is uppercases and rest are lowercased
+`-segment_case` feature enables tokenizer to segment words into subwords with one of 3 casing types (truecase ('House'), uppercase ('HOUSE') or lowercase ('house')), which helps  restore right casing during  detokenization. This feature is especially useful for texts with a signficant number of words with mixed casing ('WiFi' -> 'Wi' and 'Fi').
 ```text
 WiFi --> Wi￨C Fi￨C
 TVs --> Tv￨C s￨l

--- a/docs/tools/tokenization.md
+++ b/docs/tools/tokenization.md
@@ -27,8 +27,8 @@ th tools/detokenize.lua OPTIONS < file.tok > file.detok
 ## Mixed casing words
 `-segment_case` feature enables tokenizer to segment words into subwords with one of 3 casing types (truecase ('House'), uppercase ('HOUSE') or lowercase ('house')), which helps  restore right casing during  detokenization. This feature is especially useful for texts with a signficant number of words with mixed casing ('WiFi' -> 'Wi' and 'Fi').
 ```text
-WiFi --> Wi￨C Fi￨C
-TVs --> Tv￨C s￨l
+WiFi --> wi￨C fi￨C
+TVs --> tv￨C s￨l
 ```
 
 ## BPE

--- a/tools/learn_bpe.lua
+++ b/tools/learn_bpe.lua
@@ -28,6 +28,10 @@ local options = {
     }
   },
   {
+    '-segment_case', false,
+    [[Segment case feature, splits AbC to Ab C to be able to restore case]]
+  },
+  {
     '-lc', false,
     [[Lowercase the output from the tokenizer before learning BPE.]]
   },

--- a/tools/utils/case.lua
+++ b/tools/utils/case.lua
@@ -63,6 +63,31 @@ function case.addCase (toks)
   return toks
 end
 
+-- Segment tokens by case in order to have only Abc abc ABC words
+function case.segmentCase (toks, separator)
+  local caseSegment = {}
+  for i=1, #toks do
+    local casefeat = 'N'
+    local newTok = ''
+
+    for v, c in unicode.utf8_iter(toks[i]) do
+      local is_letter, thecase = unicode.isLetter(v)
+      if is_letter then
+        if case.combineCase(casefeat, thecase) == 'M' then
+          table.insert(caseSegment, newTok..separator)
+          newTok = ''
+          casefeat = case.combineCase('N', thecase)
+        else
+          casefeat = case.combineCase(casefeat, thecase)
+        end
+      end
+      newTok = newTok..c
+    end
+    table.insert(caseSegment, newTok)
+  end
+  return caseSegment
+end
+
 function case.restoreCase(w, feats)
   assert(#feats>=1)
   if feats[1] == 'L' or feats[1] == 'N' then

--- a/tools/utils/tokenizer.lua
+++ b/tools/utils/tokenizer.lua
@@ -232,7 +232,9 @@ function tokenizer.tokenize(opt, line, bpe)
 
   -- apply segmetn feature if requested
   if opt.segment_case then
-    tokens = case.segmentCase(tokens, opt.joiner)
+    local sep = ''
+    if opt.joiner_annotate then sep = opt.joiner end
+    tokens = case.segmentCase(tokens, sep)
   end
 
   -- apply bpe if requested

--- a/tools/utils/tokenizer.lua
+++ b/tools/utils/tokenizer.lua
@@ -31,6 +31,10 @@ local options = {
     [[Generate case feature.]]
   },
   {
+    '-segment_case', false,
+    [[Segment case feature, splits AbC to Ab C to be able to restore case]]
+  },
+  {
     '-bpe_model', '',
     [[Apply Byte Pair Encoding if the BPE model path is given. If the option is used,
       `-mode` will be overridden/set automatically if the BPE model specified by `-bpe_model`
@@ -225,6 +229,11 @@ end
 function tokenizer.tokenize(opt, line, bpe)
   -- tokenize
   local tokens = tokenize(line, opt)
+
+  -- apply segmetn feature if requested
+  if opt.segment_case then
+    tokens = case.segmentCase(tokens, opt.joiner)
+  end
 
   -- apply bpe if requested
   if bpe then


### PR DESCRIPTION
With this option tokenizer splits words like WiFi to two words Wi Fi, so we can restore correct casing with detokenizer.
Example:

```
echo "Abc ABC ABc abC AbC" | th tools/tokenize.lua -joiner_annotate -case_feature -mode aggressive -segment_case | th tools/detokenize.lua -case_feature

Abc ABC ABc abC AbC
```