### PR TITLE
Revisit padding management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes and improvements
 
 * SeqTagger supports input vector too
+* Fix incorrect gradients when using variable length batches and bidirectional encoders
 
 ## [v0.7.1](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.7.1) (2017-05-29)
 

--- a/onmt/Seq2Seq.lua
+++ b/onmt/Seq2Seq.lua
@@ -110,7 +110,6 @@ end
 function Seq2Seq:__init(args, dicts)
   parent.__init(self, args)
   onmt.utils.Table.merge(self.args, onmt.utils.ExtendedCmdLine.getModuleOpts(args, options))
-  self.args.uneven_batches = args.uneven_batches
 
   if not dicts.src then
     -- the input is already a vector
@@ -141,7 +140,6 @@ function Seq2Seq.load(args, models, dicts)
 
   parent.__init(self, args)
   onmt.utils.Table.merge(self.args, onmt.utils.ExtendedCmdLine.getModuleOpts(args, options))
-  self.args.uneven_batches = args.uneven_batches
 
   self.models.encoder = onmt.Factory.loadEncoder(models.encoder)
   self.models.decoder = onmt.Factory.loadDecoder(models.decoder)
@@ -197,30 +195,13 @@ function Seq2Seq:getOutput(batch)
   return batch.targetOutput
 end
 
-function Seq2Seq:maskPadding(batch)
-  self.models.encoder:maskPadding()
-  if batch and batch.uneven then
-    self.models.decoder:maskPadding(self.models.encoder:contextSize(batch.sourceSize, batch.sourceLength))
-  else
-    self.models.decoder:maskPadding()
-  end
-end
-
 function Seq2Seq:forwardComputeLoss(batch)
-  if self.args.uneven_batches then
-    self:maskPadding(batch)
-  end
-
   local encoderStates, context = self.models.encoder:forward(batch)
   local decoderInitStates = self.models.bridge:forward(encoderStates)
   return self.models.decoder:computeLoss(batch, decoderInitStates, context, self.criterion)
 end
 
 function Seq2Seq:trainNetwork(batch, dryRun)
-  if self.args.uneven_batches then
-    self:maskPadding(batch)
-  end
-
   local encStates, context = self.models.encoder:forward(batch)
   local decInitStates = self.models.bridge:forward(encStates)
   local decOutputs = self.models.decoder:forward(batch, decInitStates, context)

--- a/onmt/data/BatchTensor.lua
+++ b/onmt/data/BatchTensor.lua
@@ -6,15 +6,8 @@ local BatchTensor = torch.class('BatchTensor')
 function BatchTensor:__init(T, sizes)
   self.size = T:size()[1]
   self.sourceLength = T:size()[2]
-
   self.sourceSize = sizes or torch.LongTensor(self.size):fill(self.sourceLength)
-
   self.sourceInput = T
-  self.sourceInputPadLeft = true
-
-  self.sourceInputRev = self.sourceInput
-    :index(2, torch.linspace(self.sourceLength, 1, self.sourceLength):long())
-  self.sourceInputRevPadLeft = false
 end
 
 function BatchTensor:getSourceInput(t)
@@ -22,7 +15,15 @@ function BatchTensor:getSourceInput(t)
 end
 
 function BatchTensor:variableLengths()
-  return torch.any(torch.ne(self.sourceSize, self.sourceLength))
+  return onmt.data.Batch.variableLengths(self)
+end
+
+function BatchTensor:reverseSourceInPlace()
+  for b = 1, self.size do
+    local reversedIndices = torch.linspace(self.sourceSize[b], 1, self.sourceSize[b]):long()
+    local window = {b, {self.sourceLength - self.sourceSize[b] + 1, self.sourceLength}}
+    self.sourceInput[window]:copy(self.sourceInput[window]:index(1, reversedIndices))
+  end
 end
 
 return BatchTensor

--- a/onmt/data/BatchTensor.lua
+++ b/onmt/data/BatchTensor.lua
@@ -21,4 +21,8 @@ function BatchTensor:getSourceInput(t)
   return self.sourceInput:select(2, t)
 end
 
+function BatchTensor:variableLengths()
+  return torch.any(torch.ne(self.sourceSize, self.sourceLength))
+end
+
 return BatchTensor

--- a/onmt/modules/BiEncoder.lua
+++ b/onmt/modules/BiEncoder.lua
@@ -148,16 +148,6 @@ function BiEncoder:resetPreallocation()
   self.gradContextBwdProto = torch.Tensor()
 end
 
-function BiEncoder:maskPadding()
-  self.fwd:maskPadding()
-  self.bwd:maskPadding()
-end
-
--- size of context vector
-function BiEncoder:contextSize(sourceSize, sourceLength)
-  return sourceSize, sourceLength
-end
-
 function BiEncoder:forward(batch)
   if self.statesProto == nil then
     self.statesProto = onmt.utils.Tensor.initTensorTable(self.args.numEffectiveLayers,

--- a/onmt/modules/BiEncoder.lua
+++ b/onmt/modules/BiEncoder.lua
@@ -1,15 +1,3 @@
----------------------------------------------------------------------------------
--- Local utility functions
----------------------------------------------------------------------------------
-
-local function reverseInput(batch)
-  batch.sourceInput, batch.sourceInputRev = batch.sourceInputRev, batch.sourceInput
-  batch.sourceInputFeatures, batch.sourceInputRevFeatures = batch.sourceInputRevFeatures, batch.sourceInputFeatures
-  batch.sourceInputPadLeft, batch.sourceInputRevPadLeft = batch.sourceInputRevPadLeft, batch.sourceInputPadLeft
-end
-
----------------------------------------------------------------------------------
-
 --[[ BiEncoder is a bidirectional Sequencer used for the source language.
 
 
@@ -160,29 +148,36 @@ function BiEncoder:forward(batch)
                                                 { batch.size, batch.sourceLength, self.args.hiddenSize })
 
   local fwdStates, fwdContext = self.fwd:forward(batch)
-  reverseInput(batch)
+  batch:reverseSourceInPlace()
   local bwdStates, bwdContext = self.bwd:forward(batch)
-  reverseInput(batch)
+  batch:reverseSourceInPlace()
 
-  if self.args.brnn_merge == 'concat' then
-    for i = 1, #fwdStates do
+  -- Merge final states.
+  for i = 1, #states do
+    if self.args.brnn_merge == 'concat' then
       states[i]:narrow(2, 1, self.args.rnn_size):copy(fwdStates[i])
       states[i]:narrow(2, self.args.rnn_size + 1, self.args.rnn_size):copy(bwdStates[i])
-    end
-    for t = 1, batch.sourceLength do
-      context[{{}, t}]:narrow(2, 1, self.args.rnn_size)
-        :copy(fwdContext[{{}, t}])
-      context[{{}, t}]:narrow(2, self.args.rnn_size + 1, self.args.rnn_size)
-        :copy(bwdContext[{{}, batch.sourceLength - t + 1}])
-    end
-  elseif self.args.brnn_merge == 'sum' then
-    for i = 1, #states do
+    elseif self.args.brnn_merge == 'sum' then
       states[i]:copy(fwdStates[i])
       states[i]:add(bwdStates[i])
     end
-    for t = 1, batch.sourceLength do
-      context[{{}, t}]:copy(fwdContext[{{}, t}])
-      context[{{}, t}]:add(bwdContext[{{}, batch.sourceLength - t + 1}])
+  end
+
+  -- Merge outputs.
+  for b = 1, batch.size do
+    local window = {b, {batch.sourceLength - batch.sourceSize[b] + 1, batch.sourceLength}}
+    local reversedIndices = torch.linspace(batch.sourceSize[b], 1, batch.sourceSize[b]):long()
+
+    -- Reverse outputs of the reversed encoder to align them with the regular outputs.
+    local bwdOutputs = bwdContext[window]:index(1, reversedIndices)
+    local fwdOutputs = fwdContext[window]
+
+    if self.args.brnn_merge == 'concat' then
+      context[window]:narrow(2, 1, self.args.rnn_size):copy(fwdOutputs)
+      context[window]:narrow(2, self.args.rnn_size + 1, self.args.rnn_size):copy(bwdOutputs)
+    elseif self.args.brnn_merge == 'sum' then
+      context[window]:copy(fwdOutputs)
+      context[window]:add(bwdOutputs)
     end
   end
 
@@ -221,18 +216,28 @@ function BiEncoder:backward(batch, gradStatesOutput, gradContextOutput)
 
   local gradInputFwd = self.fwd:backward(batch, gradStatesOutputFwd, gradContextOutputFwd)
 
-  -- reverse gradients of the backward context
-  local gradContextBwd = onmt.utils.Tensor.reuseTensor(self.gradContextBwdProto,
-                                                       { batch.size, batch.sourceLength, self.args.rnn_size })
+  local gradContextBwd = onmt.utils.Tensor.reuseTensor(
+    self.gradContextBwdProto,
+    { batch.size, batch.sourceLength, self.args.rnn_size })
 
-  for t = 1, batch.sourceLength do
-    gradContextBwd[{{}, t}]:copy(gradContextOutputBwd[{{}, batch.sourceLength - t + 1}])
+  -- Reverse output gradients.
+  for b = 1, batch.size do
+    local window = {b, {batch.sourceLength - batch.sourceSize[b] + 1, batch.sourceLength}}
+    local reversedIndices = torch.linspace(batch.sourceSize[b], 1, batch.sourceSize[b]):long()
+    gradContextBwd[window]:copy(gradContextOutputBwd[window]:index(1, reversedIndices))
   end
 
+  batch:reverseSourceInPlace()
   local gradInputBwd = self.bwd:backward(batch, gradStatesOutputBwd, gradContextBwd)
+  batch:reverseSourceInPlace()
 
-  for t = 1, batch.sourceLength do
-    onmt.utils.Tensor.recursiveAdd(gradInputFwd[t], gradInputBwd[batch.sourceLength - t + 1])
+  -- Add gradients coming from both directions.
+  for b = 1, batch.size do
+    local padSize = batch.sourceLength - batch.sourceSize[b]
+    for t = padSize + 1, batch.sourceLength do
+      onmt.utils.Tensor.recursiveAdd(gradInputFwd[t],
+                                     gradInputBwd[batch.sourceLength - t + 1 + padSize])
+    end
   end
 
   return gradInputFwd

--- a/onmt/modules/Decoder.lua
+++ b/onmt/modules/Decoder.lua
@@ -295,7 +295,7 @@ function Decoder:forwardOne(input, prevStates, context, prevOut, t, sourceSizes,
     if sourceLength ~= context:size(2) then
       local multiplier = math.ceil(sourceLength / context:size(2))
       sourceLength = context:size(2)
-      sourceSizes = sourceSizes:float():div(multiplier):ceil():typeAs(sourceSizes)
+      sourceSizes = sourceSizes:clone():float():div(multiplier):ceil():typeAs(sourceSizes)
     end
 
     self:addPaddingMask(sourceSizes, sourceLength)

--- a/onmt/modules/PDBiEncoder.lua
+++ b/onmt/modules/PDBiEncoder.lua
@@ -114,7 +114,7 @@ end
 
 function PDBiEncoder:forward(batch)
   -- Make source length divisible by the total reduction.
-  batch.sourceLength = math.ceil(batch.sourceLength / self.args.multiplier) * self.args.multiplier
+  batch:resizeSource(math.ceil(batch.sourceLength / self.args.multiplier) * self.args.multiplier)
 
   if self.statesProto == nil then
     self.statesProto = onmt.utils.Tensor.initTensorTable(self.args.numEffectiveLayers,
@@ -165,11 +165,12 @@ function PDBiEncoder:forward(batch)
                 context:size(3) * self.args.pdbrnn_reduction)
       end
 
-      local newSizes = batch.sourceSize
+      local newSizes = self.inputs[i].sourceSize
+        :clone()
         :float()
         :div(self.args.pdbrnn_reduction)
         :ceil()
-        :typeAs(batch.sourceSize)
+        :typeAs(self.inputs[i].sourceSize)
       table.insert(self.inputs, onmt.data.BatchTensor.new(nextContext, newSizes))
     end
   end

--- a/onmt/modules/PDBiEncoder.lua
+++ b/onmt/modules/PDBiEncoder.lua
@@ -112,33 +112,6 @@ function PDBiEncoder:resetPreallocation()
   self.gradContextProto = torch.Tensor()
 end
 
-function PDBiEncoder:maskPadding()
-  for i, layer in ipairs(self.modules) do
-    if i == 1 or self.args.pdbrnn_reduction == 1 then
-      layer:maskPadding()
-    end
-  end
-end
-
--- size of context vector
-function PDBiEncoder:contextSize(sourceSize, sourceLength)
-  local contextLength = math.ceil(sourceLength / self.args.multiplier)
-  local contextSize
-
-  if type(sourceSize) == 'table' then
-    contextSize = {}
-    for i = 1, #sourceSize do
-      table.insert(contextSize, math.ceil(sourceSize[i] / self.args.multiplier))
-    end
-  elseif type(sourceSize) == 'int' then
-    contextSize = math.ceil(sourceSize / self.args.multiplier)
-  else
-    contextSize = torch.ceil(sourceSize / self.args.multiplier)
-  end
-
-  return contextSize, contextLength
-end
-
 function PDBiEncoder:forward(batch)
   -- Make source length divisible by the total reduction.
   batch.sourceLength = math.ceil(batch.sourceLength / self.args.multiplier) * self.args.multiplier
@@ -192,7 +165,12 @@ function PDBiEncoder:forward(batch)
                 context:size(3) * self.args.pdbrnn_reduction)
       end
 
-      table.insert(self.inputs, onmt.data.BatchTensor.new(nextContext, batch.sourceSize))
+      local newSizes = batch.sourceSize
+        :float()
+        :div(self.args.pdbrnn_reduction)
+        :ceil()
+        :typeAs(batch.sourceSize)
+      table.insert(self.inputs, onmt.data.BatchTensor.new(nextContext, newSizes))
     end
   end
 

--- a/onmt/tagger/Tagger.lua
+++ b/onmt/tagger/Tagger.lua
@@ -124,8 +124,6 @@ function Tagger:buildTargetFeatures(predFeats)
 end
 
 function Tagger:tagBatch(batch)
-  self.model.models.encoder:maskPadding()
-
   local pred = {}
   local feats = {}
   for _ = 1, batch.size do

--- a/onmt/translate/DecoderAdvancer.lua
+++ b/onmt/translate/DecoderAdvancer.lua
@@ -14,10 +14,9 @@ Parameters:
   * `max_num_unks` - optional, maximum number of UNKs.
   * `decStates` - optional, initial decoder states.
   * `dicts` - optional, dictionary for additional features.
-  * `updateSeqLengthFunc` - optional, sequence length adaptation function after encoder
 
 --]]
-function DecoderAdvancer:__init(decoder, batch, context, max_sent_length, max_num_unks, decStates, dicts, length_norm, coverage_norm, eos_norm, updateSeqLengthFunc)
+function DecoderAdvancer:__init(decoder, batch, context, max_sent_length, max_num_unks, decStates, dicts, length_norm, coverage_norm, eos_norm)
   self.decoder = decoder
   self.batch = batch
   self.context = context
@@ -31,7 +30,6 @@ function DecoderAdvancer:__init(decoder, batch, context, max_sent_length, max_nu
     onmt.utils.Cuda.convert(torch.Tensor()),
     { self.batch.size, decoder.args.rnnSize })
   self.dicts = dicts
-  self.updateSeqLengthFunc = updateSeqLengthFunc
 end
 
 --[[Returns an initial beam.
@@ -46,22 +44,22 @@ function DecoderAdvancer:initBeam()
   local features = {}
   if self.dicts then
     for j = 1, #self.dicts.tgt.features do
-      features[j] = torch.IntTensor(self.batch.size):fill(onmt.Constants.EOS)
+      features[j] = onmt.utils.Cuda.convert(torch.IntTensor(self.batch.size):fill(onmt.Constants.EOS))
     end
   end
   local sourceSizes = onmt.utils.Cuda.convert(self.batch.sourceSize)
   local attnProba = torch.FloatTensor(self.batch.size, self.context:size(2))
     :fill(0.0001)
     :typeAs(self.context)
-  -- Mask padding
-  local contextSizes = sourceSizes
-  if self.updateSeqLengthFunc then
-    contextSizes = self.updateSeqLengthFunc(contextSizes, 0)
-  end
-  for i = 1,self.batch.size do
-    local pad_size = self.context:size(2) - contextSizes[i]
-    if pad_size ~= 0 then
-      attnProba[{ i, {1,pad_size} }] = 1.0
+  -- Assign maximum attention proba on padding for it to not interfer during coverage normalization.
+  for i = 1, self.batch.size do
+    local sourceSize = sourceSizes[i]
+    if self.batch.sourceLength ~= self.context:size(2) then
+      sourceSize = math.ceil(sourceSize / (self.batch.sourceLength / self.context:size(2)))
+    end
+    local padSize = self.context:size(2) - sourceSize
+    if padSize ~= 0 then
+      attnProba[{i, {1, padSize}}] = 1.0
     end
   end
 
@@ -98,13 +96,13 @@ function DecoderAdvancer:update(beam)
     table.insert(inputs, features)
   end
 
-  local contextSizes, contextLength = sourceSizes, self.batch.sourceLength
-  if self.updateSeqLengthFunc then
-    contextSizes, contextLength = self.updateSeqLengthFunc(contextSizes, contextLength)
-  end
-
-  self.decoder:maskPadding(contextSizes, contextLength)
-  decOut, decStates = self.decoder:forwardOne(inputs, decStates, context, decOut)
+  decOut, decStates = self.decoder:forwardOne(inputs,
+                                              decStates,
+                                              context,
+                                              decOut,
+                                              nil,
+                                              sourceSizes,
+                                              self.batch.sourceLength)
   t = t + 1
 
   local softmaxOut

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -274,8 +274,6 @@ function Translator:buildTargetFeatures(predFeats)
 end
 
 function Translator:translateBatch(batch)
-  self.model:maskPadding()
-
   local encStates, context = self.model.models.encoder:forward(batch)
   if self.args.dump_input_encoding then
     return encStates[#encStates]
@@ -286,7 +284,6 @@ function Translator:translateBatch(batch)
   -- Compute gold score.
   local goldScore
   if batch.targetInput ~= nil then
-    self.model:maskPadding(batch)
     goldScore = self.model.models.decoder:computeScore(batch, decInitStates, context)
   end
 
@@ -300,10 +297,7 @@ function Translator:translateBatch(batch)
                                                       self.dicts,
                                                       self.args.length_norm,
                                                       self.args.coverage_norm,
-                                                      self.args.eos_norm,
-                                                      function(sourceSize, sourceLength)
-                                                        return self.model.models.encoder:contextSize(sourceSize, sourceLength)
-                                                      end)
+                                                      self.args.eos_norm)
 
   -- Save memory by only keeping track of necessary elements in the states.
   -- Attentions are at index 4 in the states defined in onmt.translate.DecoderAdvancer.
@@ -341,15 +335,14 @@ function Translator:translateBatch(batch)
       table.remove(tokens)
       if #attn > 0 then
         table.remove(attn)
-      end
 
-      -- Remove unnecessary values from the attention vectors.
-      if batch.size > 1 then
-        local size = batch.sourceSize[b]
-        local length = batch.sourceLength
-        size, length = self.model.models.encoder:contextSize(size, length)
-        for j = 1, #attn do
-          attn[j] = attn[j]:narrow(1, length - size + 1, size)
+        -- Remove unnecessary values from the attention vectors.
+        if batch.size > 1 and batch.sourceLength == attn[1]:size(1) then
+          local size = batch.sourceSize[b]
+          local length = batch.sourceLength
+          for j = 1, #attn do
+            attn[j] = attn[j]:narrow(1, length - size + 1, size)
+          end
         end
       end
 

--- a/onmt/utils/Memory.lua
+++ b/onmt/utils/Memory.lua
@@ -34,8 +34,8 @@ function Memory.optimize(model, batch)
 
   batch = onmt.utils.Tensor.deepClone(batch)
   batch.sourceLength = 1
+  batch.sourceSize:fill(1)
   batch.targetLength = 1
-  batch.uneven = false
 
   model:trainNetwork(batch, true)
 

--- a/test/onmt/BatchTest.lua
+++ b/test/onmt/BatchTest.lua
@@ -38,7 +38,7 @@ function batchTest.simpleTrainingBatch()
 
   tester:eq(batch.sourceLength, 4)
   tester:eq(batch.sourceSize, torch.IntTensor({4, 4, 4}))
-  tester:eq(batch.uneven, false)
+  tester:eq(batch:variableLengths(), false)
   tester:eq(batch.sourceInput,
             torch.LongTensor({
               {5, 5, 5},
@@ -96,7 +96,7 @@ function batchTest.simpleTrainingBatchUneven()
 
   tester:eq(batch.sourceLength, 4)
   tester:eq(batch.sourceSize, torch.IntTensor({4, 2, 3}))
-  tester:eq(batch.uneven, true)
+  tester:eq(batch:variableLengths(), true)
   tester:eq(batch.sourceInput,
             torch.LongTensor({
               {5, onmt.Constants.PAD, onmt.Constants.PAD},
@@ -209,7 +209,7 @@ function batchTest.unevenAscending()
   }
 
   local batch = onmt.data.Batch.new(src)
-  tester:eq(batch.uneven, true)
+  tester:eq(batch:variableLengths(), true)
 end
 
 function batchTest.unevenDescending()
@@ -220,7 +220,7 @@ function batchTest.unevenDescending()
   }
 
   local batch = onmt.data.Batch.new(src)
-  tester:eq(batch.uneven, true)
+  tester:eq(batch:variableLengths(), true)
 end
 
 function batchTest.empty()

--- a/test/onmt/BatchTest.lua
+++ b/test/onmt/BatchTest.lua
@@ -47,14 +47,6 @@ function batchTest.simpleTrainingBatch()
               {8, 8, 8}
             })
   )
-  tester:eq(batch.sourceInputRev,
-            torch.LongTensor({
-              {8, 8, 8},
-              {7, 7, 7},
-              {6, 6, 6},
-              {5, 5, 5}
-            })
-  )
 
   tester:eq(batch.targetLength, 5 + 1)
   tester:eq(batch.targetSize, torch.IntTensor({3 + 1, 4 + 1, 5 + 1}))
@@ -105,14 +97,6 @@ function batchTest.simpleTrainingBatchUneven()
               {8,                  6,                  7}
             })
   )
-  tester:eq(batch.sourceInputRev,
-            torch.LongTensor({
-              {8,                  6,                  7},
-              {7,                  5,                  6},
-              {6, onmt.Constants.PAD,                  5},
-              {5, onmt.Constants.PAD, onmt.Constants.PAD}
-            })
-  )
 end
 
 function batchTest.trainingBatchWithFeatures()
@@ -148,7 +132,6 @@ function batchTest.trainingBatchWithFeatures()
   local batch = onmt.data.Batch.new(src, srcFeatures, tgt, tgtFeatures)
 
   tester:eq(#batch.sourceInputFeatures, 2)
-  tester:eq(#batch.sourceInputRevFeatures, 2)
   tester:eq(#batch.targetInputFeatures, 2)
   tester:eq(#batch.targetOutputFeatures, 2)
 
@@ -201,6 +184,123 @@ function batchTest.simpleInferenceBatchUneven()
   tester:assertNoError(function () onmt.data.Batch.new(src) end)
 end
 
+function batchTest.reverseUnevenBatch()
+  local src = {
+    torch.IntTensor({5, 6, 7, 8}),
+    torch.IntTensor({5, 6}),
+    torch.IntTensor({5, 6, 7}),
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  batch:reverseSourceInPlace()
+
+  tester:eq(batch.sourceInput,
+            torch.LongTensor({
+              {8, onmt.Constants.PAD, onmt.Constants.PAD},
+              {7, onmt.Constants.PAD,                  7},
+              {6,                  6,                  6},
+              {5,                  5,                  5}
+            })
+  )
+
+  batch:reverseSourceInPlace()
+
+  tester:eq(batch.sourceInput,
+            torch.LongTensor({
+              {5, onmt.Constants.PAD, onmt.Constants.PAD},
+              {6, onmt.Constants.PAD,                  5},
+              {7,                  5,                  6},
+              {8,                  6,                  7}
+            })
+  )
+end
+
+function batchTest.reverseUnevenBatchWithFeatures()
+  local src = {
+    torch.IntTensor({5, 6, 7, 8}),
+    torch.IntTensor({5, 6, 7}),
+  }
+  local srcFeatures = {
+    {
+      torch.IntTensor({10, 11, 12, 13}),
+      torch.IntTensor({10, 11, 12, 13})
+    },
+    {
+      torch.IntTensor({10, 11, 12}),
+      torch.IntTensor({10, 11, 12})
+    }
+  }
+
+  local batch = onmt.data.Batch.new(src, srcFeatures)
+
+  batch:reverseSourceInPlace()
+
+  tester:eq(batch.sourceInputFeatures[1],
+            torch.LongTensor({
+              {13, onmt.Constants.PAD},
+              {12,                 12},
+              {11,                 11},
+              {10,                 10}
+            })
+  )
+
+  tester:eq(batch.sourceInputFeatures[2],
+            torch.LongTensor({
+              {13, onmt.Constants.PAD},
+              {12,                 12},
+              {11,                 11},
+              {10,                 10}
+            })
+  )
+end
+
+function batchTest.increaseSourceLength()
+  local src = {
+    torch.IntTensor({5, 6, 7, 8}),
+    torch.IntTensor({5, 6}),
+    torch.IntTensor({5, 6, 7}),
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  batch:resizeSource(6)
+
+  tester:eq(batch.sourceLength, 6)
+  tester:eq(batch.sourceSize, torch.IntTensor({4, 2, 3}))
+  tester:eq(batch.sourceInput,
+            torch.LongTensor({
+              {onmt.Constants.PAD, onmt.Constants.PAD, onmt.Constants.PAD},
+              {onmt.Constants.PAD, onmt.Constants.PAD, onmt.Constants.PAD},
+              {                 5, onmt.Constants.PAD, onmt.Constants.PAD},
+              {                 6, onmt.Constants.PAD,                  5},
+              {                 7,                  5,                  6},
+              {                 8,                  6,                  7}
+            })
+  )
+end
+
+function batchTest.decreaseSourceLength()
+  local src = {
+    torch.IntTensor({5, 6, 7, 8}),
+    torch.IntTensor({5, 6}),
+    torch.IntTensor({5, 6, 7}),
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  batch:resizeSource(2)
+
+  tester:eq(batch.sourceLength, 2)
+  tester:eq(batch.sourceSize, torch.IntTensor({2, 2, 2}))
+  tester:eq(batch.sourceInput,
+            torch.LongTensor({
+              {7, 5, 6},
+              {8, 6, 7}
+            })
+  )
+end
+
 function batchTest.unevenAscending()
   local src = {
     torch.IntTensor({5, 6}),
@@ -225,6 +325,118 @@ end
 
 function batchTest.empty()
   tester:assertNoError(function () onmt.data.Batch.new() end)
+end
+
+function batchTest.inputVectors()
+  local src = {
+    torch.FloatTensor({
+      {1,  2,  3,  4},
+      {5,  6,  7,  8},
+      {9, 10, 11, 12}
+    }),
+    torch.FloatTensor({
+      {13, 14, 15, 16},
+      {17, 18, 19, 20}
+    })
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  tester:eq(batch.inputVectors, true)
+  tester:eq(batch.size, 2)
+  tester:eq(batch.sourceLength, 3)
+  tester:eq(batch:variableLengths(), true)
+
+  tester:eq(batch.sourceInput,
+            torch.Tensor({
+              {
+                {1, 2, 3, 4},
+                {0, 0, 0, 0}
+              },
+              {
+                {5,  6,  7,   8},
+                {13, 14, 15, 16}
+              },
+              {
+                { 9, 10, 11, 12},
+                {17, 18, 19, 20}
+              }
+            })
+  )
+end
+
+function batchTest.resizeInputVectors()
+  local src = {
+    torch.FloatTensor({
+      {1,  2,  3,  4},
+      {5,  6,  7,  8},
+      {9, 10, 11, 12}
+    }),
+    torch.FloatTensor({
+      {13, 14, 15, 16},
+      {17, 18, 19, 20}
+    })
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  batch:resizeSource(4)
+
+  tester:eq(batch.sourceInput,
+            torch.Tensor({
+              {
+                {0, 0, 0, 0},
+                {0, 0, 0, 0}
+              },
+              {
+                {1, 2, 3, 4},
+                {0, 0, 0, 0}
+              },
+              {
+                {5,  6,  7,   8},
+                {13, 14, 15, 16}
+              },
+              {
+                { 9, 10, 11, 12},
+                {17, 18, 19, 20}
+              }
+            })
+  )
+end
+
+function batchTest.reverseInputVectors()
+  local src = {
+    torch.FloatTensor({
+      {1,  2,  3,  4},
+      {5,  6,  7,  8},
+      {9, 10, 11, 12}
+    }),
+    torch.FloatTensor({
+      {13, 14, 15, 16},
+      {17, 18, 19, 20}
+    })
+  }
+
+  local batch = onmt.data.Batch.new(src)
+
+  batch:reverseSourceInPlace()
+
+  tester:eq(batch.sourceInput,
+            torch.Tensor({
+              {
+                {9, 10, 11, 12},
+                {0,  0,  0,  0}
+              },
+              {
+                { 5,  6,  7,  8},
+                {17, 18, 19, 20}
+              },
+              {
+                { 1,  2,  3,  4},
+                {13, 14, 15, 16}
+              }
+            })
+  )
 end
 
 return batchTest

--- a/test/onmt/DecoderTest.lua
+++ b/test/onmt/DecoderTest.lua
@@ -148,10 +148,10 @@ function decoderTest.masking()
 
   decoder:evaluate()
 
-  decoder:maskPadding(torch.LongTensor({2,5,3,5}), 5)
+  decoder:addPaddingMask(torch.LongTensor({2,5,3,5}), 5)
   tester:eq(moduleExists(decoder, 'onmt.MaskedSoftmax'), true)
 
-  decoder:maskPadding()
+  decoder:removePaddingMask()
   tester:eq(moduleExists(decoder, 'onmt.MaskedSoftmax'), false)
 end
 

--- a/test/onmt/EncoderTest.lua
+++ b/test/onmt/EncoderTest.lua
@@ -69,8 +69,6 @@ local function genericCheckMasking(encoder)
 
   local batch = onmt.data.Batch.new(src)
 
-  encoder:maskPadding()
-
   local _, context = encoder:forward(batch)
 
   tester:eq(context[2][1]:ne(0):sum(), 0)
@@ -189,12 +187,6 @@ end
 function encoderTest.pdbrnn_LSTM()
   local encoder, opt = buildEncoder(onmt.PDBiEncoder, 'LSTM')
   genericCheckDim(encoder, opt)
-  local t = torch.Tensor{10,7,21}
-  local tred, length = encoder:contextSize(t, 21)
-  tester:assertTensorEq(tred, torch.Tensor{5,4,11})
-  tester:eq(length, 11)
-  local table_red = encoder:contextSize({10,7,21},0)
-  tester:eq(table_red, {5,4,11})
 end
 
 function encoderTest.pdbrnn_saveAndLoad_LSTM()


### PR DESCRIPTION
 This PR revisits the way padding is handled on the source side.

* Remove `maskPadding` methods and automatically mask padding whenever the batch contains variable length input sequences.
* In case of bidirectional encoders:
  * pad the reversed sequence on the left (see #306),
  * reverse sequences dynamically.
* In case of pyramidal bidirectional encoders:
  * actually resize the input sequence instead of returning padding when the timestep is larger than the sequence length (which make the input padded on the left **and** right),
  * improve padding masking in higher layers.