### PR TITLE
Damerau-Levenshtein edit ratio Evaluator

### DIFF
--- a/docs/options/train.md
+++ b/docs/options/train.md
@@ -69,7 +69,7 @@
 * `-start_epoch <number>` (default: `1`)<br/>If loading from a checkpoint, the epoch from which to start.
 * `-end_epoch <number>` (default: `13`)<br/>The final epoch of the training. If = 0, train forever unless another stopping condition is met (e.g. `-min_learning_rate` is reached).
 * `-curriculum <number>` (default: `0`)<br/>For this many epochs, order the minibatches based on source length (from smaller to longer). Sometimes setting this to 1 will increase convergence speed.
-* `-validation_metric <string>` (accepted: `perplexity`, `loss`, `bleu`; default: `perplexity`)<br/>Metric to use for validation.
+* `-validation_metric <string>` (accepted: `perplexity`, `loss`, `bleu`, `dlratio`; default: `perplexity`)<br/>Metric to use for validation.
 
 ## Optimization options
 

--- a/onmt/evaluators/DLratioEvaluator.lua
+++ b/onmt/evaluators/DLratioEvaluator.lua
@@ -1,0 +1,20 @@
+local DLratioEvaluator, parent = torch.class('DLratioEvaluator', 'TranslationEvaluator')
+
+function DLratioEvaluator:__init(translatorOpt, dicts)
+  parent.__init(self, translatorOpt, dicts)
+end
+
+function DLratioEvaluator:score(predictions, references)
+  local DLratio = onmt.scorers['dlratio'](predictions, references)
+  return DLratio * 100
+end
+
+function DLratioEvaluator:compare(a, b, delta)
+  return onmt.evaluators.Evaluator.lowerIsBetter(a, b, delta)
+end
+
+function DLratioEvaluator:__tostring__()
+  return 'DLratio'
+end
+
+return DLratioEvaluator

--- a/onmt/evaluators/init.lua
+++ b/onmt/evaluators/init.lua
@@ -5,5 +5,6 @@ evaluators.LossEvaluator = require('onmt.evaluators.LossEvaluator')
 evaluators.PerplexityEvaluator = require('onmt.evaluators.PerplexityEvaluator')
 evaluators.TranslationEvaluator = require('onmt.evaluators.TranslationEvaluator')
 evaluators.BLEUEvaluator = require('onmt.evaluators.BLEUEvaluator')
+evaluators.DLratioEvaluator = require('onmt.evaluators.DLratioEvaluator')
 
 return evaluators

--- a/onmt/scorers/dlratio.lua
+++ b/onmt/scorers/dlratio.lua
@@ -2,15 +2,14 @@ local function calculate_one_dlratio(pred, ref)
   local predlen = string.len(pred)
   local reflen = string.len(ref)
   local matrix = {}
-  local cost = 1
-  
+
   -- save time if we can
   if (predlen == 0) then
     return reflen
   elseif (pred == ref) then
     return 0
   end
-  
+
   -- create the predlen x reflen matrix
   for i = 0, predlen do
     matrix[i] = {}
@@ -18,7 +17,7 @@ local function calculate_one_dlratio(pred, ref)
       matrix[i][j] = 0
     end
   end
-  
+
   -- initialize the matrix
   for i = 1, predlen do
     matrix[i][0] = i
@@ -26,7 +25,7 @@ local function calculate_one_dlratio(pred, ref)
   for j = 1, reflen do
     matrix[0][j] = j
   end
-  
+
   -- calculate Damerau-Levenshtein edit distance
   for i = 1, predlen, 1 do
     for j = 1, reflen, 1 do
@@ -42,7 +41,7 @@ local function calculate_one_dlratio(pred, ref)
       end
     end
   end
-  
+
   -- return DL edit dist
   return matrix[predlen][reflen]
 end

--- a/onmt/scorers/dlratio.lua
+++ b/onmt/scorers/dlratio.lua
@@ -1,0 +1,62 @@
+local function calculate_one_dlratio(pred, ref)
+  local predlen = string.len(pred)
+  local reflen = string.len(ref)
+  local matrix = {}
+  local cost = 1
+  
+  -- save time if we can
+  if (predlen == 0) then
+    return reflen
+  elseif (pred == ref) then
+    return 0
+  end
+  
+  -- create the predlen x reflen matrix
+  for i = 0, predlen do
+    matrix[i] = {}
+    for j = 0, reflen do
+      matrix[i][j] = 0
+    end
+  end
+  
+  -- initialize the matrix
+  for i = 1, predlen do
+    matrix[i][0] = i
+  end
+  for j = 1, reflen do
+    matrix[0][j] = j
+  end
+  
+  -- calculate Damerau-Levenshtein edit distance
+  for i = 1, predlen, 1 do
+    for j = 1, reflen, 1 do
+      local predchar = string.byte(pred, i)
+      local refchar = string.byte(ref, j)
+      matrix[i][j] = math.min(
+        matrix[i-1][j] + 1, -- Deletion
+        matrix[i][j-1] + 1, -- Insertion
+        matrix[i-1][j-1] + (predchar == refchar and 0 or 1) -- Substitution
+      )
+      if predchar == string.byte(ref, j-1) and refchar == string.byte(pred, i-1) then
+        matrix[i][j] = math.min(matrix[i][j], matrix[i-2][j-2] + (predchar == refchar and 0 or 1)) -- Transposition
+      end
+    end
+  end
+  
+  -- return DL edit dist
+  return matrix[predlen][reflen]
+end
+
+local function calculate_dlratio(preds, refs)
+  local reflensum = 0
+  local totaldist = 0
+  for x = 1, #preds do
+    local pred = table.concat(preds[x], ' ')
+    local ref = table.concat(refs[x], ' ')
+    reflensum = reflensum + string.len(ref)
+    totaldist = totaldist + calculate_one_dlratio(pred, ref)
+  end
+  return totaldist / reflensum
+end
+
+return calculate_dlratio

--- a/onmt/scorers/init.lua
+++ b/onmt/scorers/init.lua
@@ -1,7 +1,8 @@
 local scorers = {}
 
 scorers.bleu = require 'onmt.scorers.bleu'
+scorers.dlratio = require 'onmt.scorers.dlratio'
 
-scorers.list = { 'bleu' }
+scorers.list = { 'bleu', 'dlratio' }
 
 return scorers

--- a/onmt/train/Trainer.lua
+++ b/onmt/train/Trainer.lua
@@ -69,7 +69,7 @@ local options = {
     '-validation_metric', 'perplexity',
     [[Metric to use for validation.]],
     {
-      enum = { 'perplexity', 'loss', 'bleu' }
+      enum = { 'perplexity', 'loss', 'bleu', 'dlratio' }
     }
   }
 }
@@ -96,6 +96,8 @@ function Trainer:__init(args, model, dicts, firstBatch)
     self.evaluator = onmt.evaluators.LossEvaluator.new()
   elseif self.args.validation_metric == 'bleu' then
     self.evaluator = onmt.evaluators.BLEUEvaluator.new(args, dicts)
+  elseif self.args.validation_metric == 'dlratio' then
+    self.evaluator = onmt.evaluators.DLratioEvaluator.new(args, dicts)
   end
 
   model:training()

--- a/rocks/opennmt-scm-1.rockspec
+++ b/rocks/opennmt-scm-1.rockspec
@@ -69,6 +69,7 @@ build = {
     ["onmt.evaluators.PerplexityEvaluator"] = "onmt/evaluators/PerplexityEvaluator.lua",
     ["onmt.evaluators.TranslationEvaluator"] = "onmt/evaluators/TranslationEvaluator.lua",
     ["onmt.evaluators.BLEUEvaluator"] = "onmt/evaluators/BLEUEvaluator.lua",
+    ["onmt.evaluators.DLratioEvaluator"] = "onmt/evaluators/DLratioEvaluator.lua",
     ["onmt.train.init"] = "onmt/train/init.lua",
     ["onmt.train.Saver"] = "onmt/train/Saver.lua",
     ["onmt.train.EpochState"] = "onmt/train/EpochState.lua",

--- a/test/onmt/DLratioTest.lua
+++ b/test/onmt/DLratioTest.lua
@@ -1,0 +1,37 @@
+require('onmt.init')
+
+local tester = ...
+
+local DLratioTest = torch.TestSuite()
+
+local ref = {
+[[After 60 days of hard work , the scientists from Xi ' an Satellite Testing and Monitoring Center overcame various technical difficulties and successfully solved the malfunction of the Beidou Navigation Experimental Satellites ( BDNES ) .]],
+[[Currently , the satellites are running smoothly and the devices on the satellites are functioning properly .]],
+[[According to the person - in - charge , on the 3 rd Febuary 2007 , after the Beidou Navigation Experimental Satellite was launched at the Xichang Satellite Launch Center , the satellite could not function properly because the solar sailboard malfunctioned during its spread .]]}
+
+local cand = {
+[[After 60 days of fierce battle , the technical personnel of Xi ' an Satellite Monitoring and Control Center fought out several technical difficulties and successfully excluded the satellite satellite satellite malfunction .]],
+[[At present , the satellite has good attitude and the instrument works normally .]],
+[[On February 3 , 2007 , the Beidou Navigation Satellite launched a satellite in Xichang Satellite Launch Center , causing a malfunction of the satellite , according to officials concerned .]]}
+
+
+local function tok(t)
+  local tt = {}
+  for i = 1, #t do
+    local toks = {}
+    for word in t[i]:gmatch'([^%s]+)' do
+      table.insert(toks, word)
+    end
+    table.insert(tt, toks)
+  end
+  return tt
+end
+
+function DLratioTest.basic()
+    local refs = tok(ref)
+    local cands = tok(cand)
+    local dlratio = onmt.scorers['dlratio'](cands, refs)
+    tester:eq(dlratio, 0.54, 0.01)
+end
+
+return DLratioTest


### PR DESCRIPTION
Adds dlratio as an option for -validaion_metric.  Implemented so that it counts the DL edit distance for each (prediction, reference) pair (as strings), then divides the total number of edits across all pairs by the total length in characters of all reference strings.