### PR TITLE
Fix a typo in line 42: coverage norm -> eos norm

### DIFF
--- a/docs/translation/beam_search.md
+++ b/docs/translation/beam_search.md
@@ -39,7 +39,7 @@ The score of the end of sentence token is penalized by the following formula:
 
 $$ep(X,Y)=\gamma\frac{|X|}{|Y|}$$
 
-where \(|X|\) is the source length, \(|Y|\) is the current target length and \(\gamma\) is the coverage normalization coefficient `-eos_norm`.
+where \(|X|\) is the source length, \(|Y|\) is the current target length and \(\gamma\) is the end of sentence normalization coefficient `-eos_norm`.
 
 ## Visualizing the beam search
 


### PR DESCRIPTION
As illustrated in the title.