### PR TITLE
-replace_unk_tagged option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add 'Shallow Fusion' of language model in decoder
 * Add option to reset the optimizer states when the learning rate is decayed
 * Add option to dump attention in `translate.lua`
+* Add option to replace unknown words with the original wrapped in a <unk></unk> tag `-replace_unk_tagged`
 
 ### Fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Add 'Shallow Fusion' of language model in decoder
 * Add option to reset the optimizer states when the learning rate is decayed
 * Add option to dump attention in `translate.lua`
-* Add option to replace unknown words with the original wrapped in a <unk></unk> tag `-replace_unk_tagged`
+* Add option to replace unknown words with the original wrapped in a `｟unk:xxxxx｠` tag `-replace_unk_tagged`
 
 ### Fixes and improvements
 

--- a/docs/options/rest_server.md
+++ b/docs/options/rest_server.md
@@ -20,7 +20,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/rest_server.md
+++ b/docs/options/rest_server.md
@@ -20,6 +20,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/rest_server.md
+++ b/docs/options/rest_server.md
@@ -20,7 +20,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in ｟unk:xxxxx｠.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/server.md
+++ b/docs/options/server.md
@@ -18,7 +18,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/server.md
+++ b/docs/options/server.md
@@ -18,6 +18,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/server.md
+++ b/docs/options/server.md
@@ -18,7 +18,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in ｟unk:xxxxx｠.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/train.md
+++ b/docs/options/train.md
@@ -109,6 +109,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/train.md
+++ b/docs/options/train.md
@@ -109,7 +109,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/train.md
+++ b/docs/options/train.md
@@ -109,7 +109,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in ｟unk:xxxxx｠.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/translate.md
+++ b/docs/options/translate.md
@@ -24,7 +24,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in ｟unk:xxxxx｠.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/translate.md
+++ b/docs/options/translate.md
@@ -24,6 +24,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/options/translate.md
+++ b/docs/options/translate.md
@@ -24,7 +24,7 @@
 * `-beam_size <number>` (default: `5`)<br/>Beam size.
 * `-max_sent_length <number>` (default: `250`)<br/>Maximum output sentence length.
 * `-replace_unk [<boolean>]` (default: `false`)<br/>Replace the generated <unk> tokens with the source token that has the highest attention weight. If `-phrase_table` is provided, it will lookup the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table) then it will copy the source token
-* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk, but wraps the replaced token in <unk></unk>.`
+* `-replace_unk_tagged [<boolean>]` (default: `false`)<br/>The same as `-replace_unk`, but wraps the replaced token in <unk></unk>.`
 * `-phrase_table <string>` (default: `''`)<br/>Path to source-target dictionary to replace `<unk>` tokens.
 * `-n_best <number>` (default: `1`)<br/>If > 1, it will also output an n-best list of decoded sentences.
 * `-max_num_unks <number>` (default: `inf`)<br/>All sequences with more `<unk>`s than this will be ignored during beam search.

--- a/docs/translation/unknowns.md
+++ b/docs/translation/unknowns.md
@@ -1,6 +1,6 @@
 The default translation mode allows the model to produce the `<unk>` symbol when it is not sure of the specific target word.
 
-Often times `<unk>` symbols will correspond to proper names that can be directly transposed between languages. The `-replace_unk` option will substitute `<unk>` with source words that have the highest attention weight.
+Often times `<unk>` symbols will correspond to proper names that can be directly transposed between languages. The `-replace_unk` option will substitute `<unk>` with source words that have the highest attention weight. The `-replace_unk_tagged` option will do the same, but wrap the token in a <unk></unk> tag.
 
 ## Phrase table
 

--- a/docs/translation/unknowns.md
+++ b/docs/translation/unknowns.md
@@ -1,6 +1,6 @@
 The default translation mode allows the model to produce the `<unk>` symbol when it is not sure of the specific target word.
 
-Often times `<unk>` symbols will correspond to proper names that can be directly transposed between languages. The `-replace_unk` option will substitute `<unk>` with source words that have the highest attention weight. The `-replace_unk_tagged` option will do the same, but wrap the token in a <unk></unk> tag.
+Often times `<unk>` symbols will correspond to proper names that can be directly transposed between languages. The `-replace_unk` option will substitute `<unk>` with source words that have the highest attention weight. The `-replace_unk_tagged` option will do the same, but wrap the token in a ｟unk:xxxxx｠ tag.
 
 ## Phrase table
 

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -284,7 +284,6 @@ function Translator:buildTargetWords(pred, src, attn)
         elseif self.args.replace_unk_tagged then
           tokens[i] = '｟unk:' .. source .. '｠'
         end
-        
       end
     end
   end

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -42,7 +42,7 @@ local options = {
       does not exist in the table) then it will copy the source token]]},
   {
     '-replace_unk_tagged', false,
-    [[The same as -replace_unk, but wrap the replaced token in <unk>token</unk> if it is not found in the phrase table.]]},
+    [[The same as -replace_unk, but wrap the replaced token in ｟unk:xxxxx｠ if it is not found in the phrase table.]]},
   {
     '-phrase_table', '',
     [[Path to source-target dictionary to replace `<unk>` tokens.]],
@@ -293,7 +293,7 @@ function Translator:buildTargetWords(pred, src, attn)
         if self.phraseTable and self.phraseTable:contains(source) then
           tokens[i] = self.phraseTable:lookup(source)
         else
-          tokens[i] = "<unk>"..source.."</unk>"
+          tokens[i] = "｟unk:"..source.."｠"
         end
       end
     end

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -41,6 +41,9 @@ local options = {
       target token. If it is not provided (or the identified source token
       does not exist in the table) then it will copy the source token]]},
   {
+    '-replace_unk_tagged', false,
+    [[The same as -replace_unk, but wrap the replaced token in <unk>token</unk> if it is not found in the phrase table.]]},
+  {
     '-phrase_table', '',
     [[Path to source-target dictionary to replace `<unk>` tokens.]],
     {
@@ -276,6 +279,21 @@ function Translator:buildTargetWords(pred, src, attn)
           tokens[i] = self.phraseTable:lookup(source)
         else
           tokens[i] = source
+        end
+      end
+    end
+  end
+
+  if self.args.replace_unk_tagged then
+    for i = 1, #tokens do
+      if tokens[i] == onmt.Constants.UNK_WORD then
+        local _, maxIndex = attn[i]:max(1)
+        local source = src[maxIndex[1]]
+
+        if self.phraseTable and self.phraseTable:contains(source) then
+          tokens[i] = self.phraseTable:lookup(source)
+        else
+          tokens[i] = "<unk>"..source.."</unk>"
         end
       end
     end

--- a/onmt/translate/Translator.lua
+++ b/onmt/translate/Translator.lua
@@ -269,7 +269,7 @@ end
 function Translator:buildTargetWords(pred, src, attn)
   local tokens = self.dicts.tgt.words:convertToLabels(pred, onmt.Constants.EOS)
 
-  if self.args.replace_unk then
+  if self.args.replace_unk or self.args.replace_unk_tagged then
     for i = 1, #tokens do
       if tokens[i] == onmt.Constants.UNK_WORD then
         local _, maxIndex = attn[i]:max(1)
@@ -277,24 +277,14 @@ function Translator:buildTargetWords(pred, src, attn)
 
         if self.phraseTable and self.phraseTable:contains(source) then
           tokens[i] = self.phraseTable:lookup(source)
-        else
+
+        elseif self.args.replace_unk then
           tokens[i] = source
-        end
-      end
-    end
-  end
 
-  if self.args.replace_unk_tagged then
-    for i = 1, #tokens do
-      if tokens[i] == onmt.Constants.UNK_WORD then
-        local _, maxIndex = attn[i]:max(1)
-        local source = src[maxIndex[1]]
-
-        if self.phraseTable and self.phraseTable:contains(source) then
-          tokens[i] = self.phraseTable:lookup(source)
-        else
-          tokens[i] = "｟unk:"..source.."｠"
+        elseif self.args.replace_unk_tagged then
+          tokens[i] = '｟unk:' .. source .. '｠'
         end
+        
       end
     end
   end


### PR DESCRIPTION
Hello Everyone,

I added an option to replace unknown words with the token with the highest attention vector like -replace_unk, but wrapping it in `<unk>Original_token</unk>`. It would make sense to me to not have to maintain a fork just to have this option, so here it is. If there are any problems or suggestions I’m open to changing it.

Regards,
Bart