### PR TITLE
Travis docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,75 +1,23 @@
+sudo: required 
 language: c
-compiler:
-  - gcc
-cache:
-  directories:
-    - $HOME/OpenBlasInstall
-    - $HOME/torch
-sudo: false
-env:
-  - TORCH_LUA_VERSION=LUAJIT21
-  - TORCH_LUA_VERSION=LUA52
-addons:
-  apt:
-    packages:
-      - cmake
-      - gfortran
-      - gcc-multilib
-      - gfortran-multilib
-      - liblapack-dev
-      - build-essential
-      - gcc
-      - g++
-      - curl
-      - libreadline-dev
-      - git-core
-      - libqt4-core
-      - libqt4-gui
-      - libqt4-dev
-      - libjpeg-dev
-      - libpng-dev
-      - ncurses-dev
-      - imagemagick
-      - libzmq3-dev
-      - gfortran
-      - unzip
-      - gnuplot
-      - gnuplot-x11
-install:
-  - export ROOT_TRAVIS_DIR=$(pwd)
-  - export INSTALL_PREFIX=~/torch/install
-  - export PATH=${INSTALL_PREFIX}/bin:$PATH
-  - ls $HOME/OpenBlasInstall/lib ||
-    (cd /tmp/
-    && git clone https://github.com/xianyi/OpenBLAS.git -b master
-    && cd OpenBLAS
-    && (make NO_AFFINITY=1 -j$(getconf _NPROCESSORS_ONLN) 2>/dev/null >/dev/null)
-    && make PREFIX=$HOME/OpenBlasInstall install)
-  - ls $INSTALL_PREFIX ||
-    (git clone https://github.com/torch/distro.git ~/torch --recursive
-    && cd ~/torch
-    && git submodule update --init --recursive
-    && mkdir build && cd build
-    && export CMAKE_LIBRARY_PATH=$HOME/OpenBlasInstall/include:$HOME/OpenBlasInstall/lib:$CMAKE_LIBRARY_PATH
-    && cmake .. -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_BUILD_TYPE=Release -DWITH_${TORCH_LUA_VERSION}=ON
-    && make && make install
-    && cd $ROOT_TRAVIS_DIR
-    && export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$LD_LIBRARY_PATH
-    && luarocks install torch
-    && luarocks install nn
-    && luarocks install nngraph
-    && luarocks install tds
-    && luarocks install bit32 || true
-    && luarocks install luacheck
-    && luarocks install penlight
-    && luarocks install optim
-    && luarocks install luacov)
+services:
+  - docker
+before_install:
+  - sudo docker pull opennmt/opennmt:latest
+  - sudo docker build -t opennmt/opennmt:latest --cache-from opennmt/opennmt:latest .
+  - sudo docker run -itd --name build -v $(pwd):/repo -w /repo opennmt/opennmt:latest
 before_script:
-  - export LUA=$(which luajit lua | head -n 1)
+  - export LUA=$(docker exec build which luajit lua | head -n 1)
 script:
-  - luacheck *lua onmt/ tools/ benchmark/ test/
-  - luarocks make rocks/opennmt-scm-1.rockspec
-  - ${LUA} -lluacov test/test.lua -e "${LUA} -lluacov"
-  - luacov
+  - sudo docker exec build luacheck *lua /repo/onmt/ /repo/tools/ /repo/benchmark/ /repo/test/
+  - sudo docker exec build luarocks make rocks/opennmt-scm-1.rockspec
+  - sudo docker exec build ${LUA} -lluacov test/test.lua -e "${LUA} -lluacov"
+  - sudo docker exec build luacov
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  - |
+        if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+            docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+            sudo docker tag opennmt/opennmt:latest opennmt/opennmt:$TRAVIS_BUILD_NUMBER
+            docker push opennmt/opennmt
+        fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 # Start with CUDA Torch dependencies 2
-FROM kaixhin/cuda-torch-deps:2-8.0
-MAINTAINER Kai Arulkumaran <design@kaixhin.com>
-
-# Restore Torch7 installation script
-RUN sed -i 's/path_to_nvcc=$(which no_nvcc)/path_to_nvcc=$(which nvcc)/g' install.sh
+FROM kaixhin/cuda-torch:8.0
+MAINTAINER OpenNMT <http://opennmt.net/>
 
 RUN sudo apt-get install -y libzmq-dev
 
-# Install CUDA libraries
-RUN luarocks install cutorch && \
-  luarocks install cunn && \
-  luarocks install cudnn && \
-  luarocks install tds
+# Needed libs for luarocks--audio
+RUN sudo apt-get install -y libfftw3-dev libsox-dev
+
+RUN luarocks install tds
 RUN luarocks install dkjson
 RUN luarocks install lua-zmq ZEROMQ_LIBDIR=/usr/lib/x86_64-linux-gnu/ ZEROMQ_INCDIR=/usr/include
 RUN luarocks install sundown
@@ -37,3 +33,8 @@ RUN luarocks install graphicsmagick
 RUN luarocks install argcheck
 RUN luarocks install audio
 RUN luarocks install signal
+RUN luarocks install bit32
+
+#Needed for test
+RUN luarocks install luacheck && \
+    luarocks install luacov


### PR DESCRIPTION
The aim of this PR is to use the Dockerfile included in the repository to setup the test environment for travis-ci.
I can see the following advantages to do so:
- Speed up travis-ci jobs (I observed that the travis-ci job takes only ten minutes now, to be compared with the twenty minutes before: [build #9](https://travis-ci.org/aurelien-coquard/OpenNMT/builds/275604717))
- Validate that the Dockerfile is still compatible with current code (detect if Dockerfile needs an update)
- Avoid code duplication (similar code in `Dockerfile` and in `.travis.yml`)

In order not to rebuild the whole Docker image each time, the travis-ci script pull and push images from a Docker repository. I temporally used my repository on [Docker Hub](https://hub.docker.com/u/aureliencoquard/) as I currently don't have access to [OpenNMT repository](https://hub.docker.com/u/opennmt/), but this is the one that should be used on the official github repository.

So, if this PR is accepted, before merging it, all references to my Docker repository should be replaced by references to OpenNMT official repository. Also, credentials to connect this Docker repository should be added to travis OpenNMT account settings (see [Travis Documentation](https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry)). Indeed, the new travis-ci job, appart from executing the tests, is also responsible for updating Docker images when Dockerfile changes and needs credentials to push to Docker repository.

For reference, here is the TODO list before merging:
- [x] tag and push the first image to [opennmt/opennmt repo](https://hub.docker.com/r/opennmt/opennmt/):
```
$ docker pull aureliencoquard/opennmt:latest
$ docker tag aureliencoquard/opennmt:latest opennmt/opennmt:8.0
$ docker tag aureliencoquard/opennmt:latest opennmt/opennmt:latest
$ docker push opennmt/opennmt
```
- [ ] Add Docker credentials for opennmt to [travis-ci setting](https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry)
- [x] Modify `.travis.yml`: replace all references to 'aureliencoquard' with 'opennmt'
- [x] Commit and push
