### PR TITLE
Git with openssl in Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: c
 services:
   - docker
 before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - sudo docker pull opennmt/opennmt:latest
   - sudo docker build -t opennmt/opennmt:latest --cache-from opennmt/opennmt:latest .
   - sudo docker run -itd --name build -v $(pwd):/repo -w /repo opennmt/opennmt:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,60 @@
+# Re-compile git with openssl rather than gnutls because of issue with AWS CodeCommit
+# Using multi-stage builds docker feature
+FROM ubuntu:14.04 as builder
+RUN sudo sed -i 's/# \(deb-src.*\)/\1/g' /etc/apt/sources.list
+RUN sudo apt-get update && \
+    sudo apt-get install -y build-essential fakeroot dpkg-dev && \
+    sudo apt-get build-dep -y git && \
+    sudo apt-get install -y libcurl4-openssl-dev
+RUN mkdir /tmp/git-openssl && \
+    cd /tmp/git-openssl && \
+    apt-get source git && \
+    dpkg-source -x git_1.9.1-1ubuntu0.6.dsc && \
+    cd git-1.9.1 && \
+    sed -i 's/libcurl4-gnutls-dev/libcurl4-openssl-dev/g' debian/control && \
+    sed -i '/^TEST =test$/d' debian/rules && \
+    sudo dpkg-buildpackage -rfakeroot -b
+
 # Start with CUDA Torch dependencies 2
 FROM kaixhin/cuda-torch:8.0
 MAINTAINER OpenNMT <http://opennmt.net/>
 
-RUN sudo apt-get install -y libzmq-dev
+#use git-openssl from previous build stage
+COPY --from=builder /tmp/git-openssl/git_1.9.1-1ubuntu0.6_amd64.deb /tmp/
+RUN sudo dpkg -i /tmp/git_1.9.1-1ubuntu0.6_amd64.deb
 
-# Needed libs for luarocks--audio
-RUN sudo apt-get install -y libfftw3-dev libsox-dev
+# Needed libs for luarocks--audio and zmq server
+RUN sudo apt-get install -y libzmq-dev libfftw3-dev libsox-dev
 
-RUN luarocks install tds
-RUN luarocks install dkjson
-RUN luarocks install lua-zmq ZEROMQ_LIBDIR=/usr/lib/x86_64-linux-gnu/ ZEROMQ_INCDIR=/usr/include
-RUN luarocks install sundown
-RUN luarocks install cwrap
-RUN luarocks install paths
-RUN luarocks install torch
-RUN luarocks install nn
-RUN luarocks install dok
-RUN luarocks install gnuplot
-RUN luarocks install qtlua
-RUN luarocks install qttorch
-RUN luarocks install luafilesystem
-RUN luarocks install penlight
-RUN luarocks install sys
-RUN luarocks install xlua
-RUN luarocks install image
-RUN luarocks install optim
-RUN luarocks install lua-cjson
-RUN luarocks install trepl
-RUN luarocks install nnx
-RUN luarocks install threads
-RUN luarocks install graphicsmagick
-RUN luarocks install argcheck
-RUN luarocks install audio
-RUN luarocks install signal
-RUN luarocks install bit32
-
-#Needed for test
+# Needed for test
 RUN luarocks install luacheck && \
     luarocks install luacov
+
+RUN luarocks install tds && \
+    luarocks install dkjson && \
+    luarocks install lua-zmq ZEROMQ_LIBDIR=/usr/lib/x86_64-linux-gnu/ ZEROMQ_INCDIR=/usr/include && \
+    luarocks install sundown && \
+    luarocks install cwrap && \
+    luarocks install paths && \
+    luarocks install torch && \
+    luarocks install nn && \
+    luarocks install dok && \
+    luarocks install gnuplot && \
+    luarocks install qtlua && \
+    luarocks install qttorch && \
+    luarocks install luafilesystem && \
+    luarocks install penlight && \
+    luarocks install sys && \
+    luarocks install xlua && \
+    luarocks install image && \
+    luarocks install optim && \
+    luarocks install lua-cjson && \
+    luarocks install trepl && \
+    luarocks install nnx && \
+    luarocks install threads && \
+    luarocks install graphicsmagick && \
+    luarocks install argcheck && \
+    luarocks install audio && \
+    luarocks install signal && \
+    luarocks install bit32
+


### PR DESCRIPTION
OpenNMT Docker image is using an official Ubuntu image as a base.
In this image, git is compiled with gnutls. This causes an issue when cloning a repository in https.
This is the case for example when cloning an AWS CodeCommit repository with a read-only user.
See [error-gnutls_handshake-failed](https://confluence.atlassian.com/bitbucketserverkb/error-gnutls_handshake-failed-a-tls-warning-alert-has-been-received-779171747.html)

To fix that, this MR proposes to first compile git with openssl with a dedicated temporary image and then copy the resulting `.deb` for installation inside the current opennmt docker image. This is using the multi-stage builds docker feature that allows not to incorporate into the final image all the build tools necessary for the compilation of git. As this feature is only available since Docker 17.05.0, Docker needs to upgraded from `.travis-ci.yml`.

This MR also incorporate some refactoring of the Dockerfile. It especially reduces the number of `RUN` command to limit the number of layers inside the image.