### PR TITLE
Add a dry run mode for the preprocess

### DIFF
--- a/docs/options/preprocess.md
+++ b/docs/options/preprocess.md
@@ -10,7 +10,8 @@
 ## Preprocess options
 
 * `-data_type <string>` (accepted: `bitext`, `monotext`, `feattext`; default: `bitext`)<br/>Type of data to preprocess. Use 'monotext' for monolingual data. This option impacts all options choices.
-* `-save_data <string>` (required)<br/>Output file for the prepared data.
+* `-dry_run [<boolean>]` (default: `false`)<br/>If set, this will only prepare the preprocessor. Useful when using file sampling to test distribution rules.
+* `-save_data <string>` (default: `''`)<br/>Output file for the prepared data.
 
 ## Data options
 

--- a/docs/training/sampling.md
+++ b/docs/training/sampling.md
@@ -96,3 +96,8 @@ The weights are dynamically normalized to 1. Here we will make sure that 65% of 
 !!! warning "Warning"
     If one file could not be match by a rule, it would be completely excluded.
 
+To test your distribution rules, it is possible to execute a dry run of the preprocessor:
+
+```bash
+th preprocess.lua -gsample_dist rules.txt -gsample 100000 -train_dir data/ -dry_run
+```

--- a/onmt/data/Preprocessor.lua
+++ b/onmt/data/Preprocessor.lua
@@ -334,7 +334,7 @@ function Preprocessor:parseDirectory(args, datalist, dist_rules, type)
     for i = 1, #list_files do
       list_files[i].weight = list_files[i].weight / sum_weight
       if list_files[i].weight > 0 then
-        _G.logger:info(" * file '%s' uniform weight: %.1f, (rule: %d) distribution weight: %.1f",
+        _G.logger:info(" * file '%s' uniform weight: %.3f, (rule: %d) distribution weight: %.3f",
                        list_files[i].fname,
                        100 * list_files[i][1] / totalCount,
                        list_files[i].rule_idx or 0,

--- a/onmt/data/Preprocessor.lua
+++ b/onmt/data/Preprocessor.lua
@@ -461,7 +461,9 @@ function Preprocessor:__init(args, dataType)
   -- list and check training files
   if args.train_dir ~= '' then
     onmt.utils.Error.assert(isempty(self.trains) == #self.trains, 'For directory mode, file mode options (training) should not be set')
-    onmt.utils.Error.assert(isempty(self.vocabs) == 0, 'For directory mode, vocabs should be predefined')
+    if not args.dry_run then
+      onmt.utils.Error.assert(isempty(self.vocabs) == 0, 'For directory mode, vocabs should be predefined')
+    end
     self.totalCount, self.list_train = self:parseDirectory(self.args, Preprocessor.getDataList(self.dataType), self.dist_rules, 'train')
   else
     onmt.utils.Error.assert(isempty(self.trains) == 0)

--- a/onmt/data/Preprocessor.lua
+++ b/onmt/data/Preprocessor.lua
@@ -333,8 +333,13 @@ function Preprocessor:parseDirectory(args, datalist, dist_rules, type)
     -- final normalization of weights
     for i = 1, #list_files do
       list_files[i].weight = list_files[i].weight / sum_weight
-      _G.logger:info(" * file '"..list_files[i].fname.."' uniform weight: %.1f, (rule: %d) distribution weight: %.1f",
-                     100*list_files[i][1]/totalCount, list_files[i].rule_idx or 0, 100*list_files[i].weight)
+      if list_files[i].weight > 0 then
+        _G.logger:info(" * file '%s' uniform weight: %.1f, (rule: %d) distribution weight: %.1f",
+                       list_files[i].fname,
+                       100 * list_files[i][1] / totalCount,
+                       list_files[i].rule_idx or 0,
+                       100 * list_files[i].weight)
+      end
     end
     _G.logger:info('')
   else

--- a/preprocess.lua
+++ b/preprocess.lua
@@ -17,10 +17,15 @@ local options = {
     }
   },
   {
+    '-dry_run', false,
+    [[If set, this will only prepare the preprocessor. Useful when using file sampling to
+      test distribution rules.]]
+  },
+  {
     '-save_data', '',
     [[Output file for the prepared data.]],
     {
-      valid = onmt.utils.ExtendedCmdLine.nonEmpty
+      depends = function(opt) return opt.dry_run, "option `-save_data` is required" end
     }
   }
 }
@@ -50,6 +55,11 @@ local function main()
   _G.logger = onmt.utils.Logger.new(opt.log_file, opt.disable_logs, opt.log_level)
 
   local Preprocessor = onmt.data.Preprocessor.new(opt, dataType)
+
+  if opt.dry_run then
+    _G.logger:shutDown()
+    return
+  end
 
   local data = { dataType=dataType }
 


### PR DESCRIPTION
As distribution rules involve pattern matching, it is easy to make a mistake and, in the current workflow, difficult to validate.

I propose to add a `-dry_run` flag to `preprocess.lua` to only prepare the preprocessor and log matched files and weights. For example:

```
th preprocess.lua -gsample_dist rules.txt -gsample 100000 -train_dir data/ -dry_run
```

This will allow quick validation and testing of the distribution rules files.