### PR TITLE
Make decoder embeddings optional in tools/extract_embeddings.lua

### DIFF
--- a/onmt/SeqTagger.lua
+++ b/onmt/SeqTagger.lua
@@ -1,4 +1,4 @@
---[[ Sequence to sequence model with attention. ]]
+--[[ Sequence tagger. ]]
 local SeqTagger, parent = torch.class('SeqTagger', 'Model')
 
 local options = {

--- a/tools/extract_embeddings.lua
+++ b/tools/extract_embeddings.lua
@@ -40,8 +40,9 @@ local function main()
   end
   local dicts = checkpoint.dicts
   local encoder = onmt.Factory.loadEncoder(checkpoint.models.encoder)
+  local decoder
   if checkpoint.models.decoder then
-    local decoder = onmt.Factory.loadDecoder(checkpoint.models.decoder)
+    decoder = onmt.Factory.loadDecoder(checkpoint.models.decoder)
   end
   local encoder_embeddings, decoder_embeddings
 
@@ -55,7 +56,7 @@ local function main()
       end
   end)
 
-  if checkpoint.models.decoder then
+  if decoder then
     decoder:apply(function(m)
         if torch.type(m) == "onmt.WordEmbedding" then
           print("Found target embeddings of size " ..  m.net.weight:size(1))

--- a/tools/extract_embeddings.lua
+++ b/tools/extract_embeddings.lua
@@ -40,7 +40,9 @@ local function main()
   end
   local dicts = checkpoint.dicts
   local encoder = onmt.Factory.loadEncoder(checkpoint.models.encoder)
-  local decoder = onmt.Factory.loadDecoder(checkpoint.models.decoder)
+  if checkpoint.models.decoder then
+    local decoder = onmt.Factory.loadDecoder(checkpoint.models.decoder)
+  end
   local encoder_embeddings, decoder_embeddings
 
   encoder:apply(function(m)
@@ -53,22 +55,25 @@ local function main()
       end
   end)
 
-  decoder:apply(function(m)
-      if torch.type(m) == "onmt.WordEmbedding" then
-        print("Found target embeddings of size " ..  m.net.weight:size(1))
-        if m.net.weight:size(1) == dicts.tgt.words:size() then
-          decoder_embeddings = m.net.weight
+  if checkpoint.models.decoder then
+    decoder:apply(function(m)
+        if torch.type(m) == "onmt.WordEmbedding" then
+          print("Found target embeddings of size " ..  m.net.weight:size(1))
+          if m.net.weight:size(1) == dicts.tgt.words:size() then
+            decoder_embeddings = m.net.weight
+          end
+          return
         end
-        return
-      end
-  end)
+    end)
+  end
 
   print("Writing source embeddings")
   write_embeddings(opt.output_dir .. "/src_embeddings.txt", dicts.src.words, encoder_embeddings)
 
-  print("Writing target embeddings")
-  write_embeddings(opt.output_dir .. "/tgt_embeddings.txt", dicts.tgt.words, decoder_embeddings)
-
+  if checkpoint.models.decoder then
+    print("Writing target embeddings")
+    write_embeddings(opt.output_dir .. "/tgt_embeddings.txt", dicts.tgt.words, decoder_embeddings)
+  end
   print('... done.')
 end
 


### PR DESCRIPTION
When extracting embeddings from SeqTagger or LanguageModel models extract_embeddings throws error since there is no decoder. With this fix we first check if decoder exists, and only then extract embeddings from it.

There was also a typo in SeqTagger.lua description