### PR TITLE
Enable evaluation mode for language models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fix beam-size 1 broken with lexical constraints
 * Fix batch size non function with `rest_translation_server.lua`
+* Fix non deterministic inference of language models
 
 ## [v0.9.7](https://github.com/OpenNMT/OpenNMT/releases/tag/v0.9.7) (2017-12-19)
 

--- a/onmt/lm/LM.lua
+++ b/onmt/lm/LM.lua
@@ -48,6 +48,7 @@ function LM:__init(args)
   end
 
   self.model = onmt.LanguageModel.load(self.checkpoint.options, self.checkpoint.models, self.checkpoint.dicts)
+  self.model:evaluate()
   onmt.utils.Cuda.convert(self.model)
 
   self.dicts = self.checkpoint.dicts


### PR DESCRIPTION
Evaluation mode should be invoked to disable dropout.

Fixes #495.
Fixes #445.