### PR TITLE
Add hook for additional mecab tokenization after lua tokenization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Introduce `max_tokens` allowing longer sentence handling and larger batch size
 * Add `-log_tag` option to add tag in logs for better automatic processing
 * The `withAttn` option in rest translation server now also returns the source and target tokens
+* Add hook for korean and japanese tokenization 
 
 ### Fixes and improvements
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -44,3 +44,27 @@ Once the REST server is running, you can use it during tokenization as follows:
 ```
 th tools/tokenize.lua -hook_file hooks.tree-tagger -pos_feature < file
 ``` 
+
+## Mecab tokenization
+
+Processing additional tokenization after lua tokenization
+
+In the case of Korean and Japanese, there is a case where several words are combined into one word, meaning that they are separated by semantics.
+
+```
+ehco "이것은 테스트-셈플입니다." | th tools/tokenize.lua -hook_file hooks/mecab
+이것 은 테스트 - 셈플 입니다 .
+echo "이것은 테스트-셈플입니다." | th tools/tokenize.lua -hook_file hooks/mecab -joiner_annotate true
+이것￭ 은 테스트￭ -￭ 셈플￭ 입니다 ￭.
+echo "이것은 테스트-셈플입니다." | th tools/tokenize.lua -mode aggressive -hook_file hooks/mecab -joiner_annotate true
+이것￭ 은 테스트 ￭-￭ 셈플￭ 입니다 ￭.
+```
+
+Install mecab and mecab-dic
+* [Korean mecab and mecab-dic](https://bitbucket.org/eunjeon/mecab-ko)
+* [Japanese mecab and mecab-dic](http://taku910.github.io/mecab/)
+
+Install lua-mecab
+```
+luarocks install mecab
+``` 

--- a/hooks/mecab.lua
+++ b/hooks/mecab.lua
@@ -1,0 +1,34 @@
+local mecab = require("mecab")
+local parser = mecab:new("-Owakati")
+local String = require ('onmt.utils.String')
+
+local function mecab(sentence, opt)
+  tokens = parser:parse(sentence)
+  tokens = tokens:gsub( "%s+$", "")
+  if opt.joiner_annotate then
+    tokens = tokens:gsub("%s+", opt.joiner .. " ")
+  end
+  return String.split(tokens, " ")
+end
+
+function mytokenization(opt, tokens)
+  res = {}
+  for idx=1, #tokens do
+    if opt.joiner_annotate then 
+      if string.match(tokens[idx], opt.joiner) then
+        table.insert(res, tokens[idx])
+      else
+        mecabTok = mecab(tokens[idx], opt)
+        for k, v in pairs(mecabTok) do table.insert(res, v) end
+        end
+      else
+        mecabTok = mecab(tokens[idx], opt)
+        for k, v in pairs(mecabTok) do table.insert(res, v) end
+      end
+    end
+    return res
+end
+
+return {
+  additional_tokenize = mytokenization
+}

--- a/tools/utils/tokenizer.lua
+++ b/tools/utils/tokenizer.lua
@@ -345,6 +345,9 @@ function tokenizer.tokenize(opt, line, bpe)
     -- tokenize
     tokens = tokenize(line, opt)
 
+    -- mecab tokenize hook, additional tokenize after lua tokenization
+    tokens = _G.hookManager:call("additional_tokenize", opt, tokens) or tokens
+
     -- apply segment feature if requested
     if opt.segment_case then
       local sep = ''


### PR DESCRIPTION
I explained hear http://forum.opennmt.net/t/could-i-submit-pull-request-to-tokenization-hook-for-korean-and-japanese/1602 .

Just processing additional tokenization after lua tokenization, it raise bleu score pretty much. 

Use OpenNMT Tokenization
en2ko : 17.77   +/-5.03 BLEU = 18.33, 55.6/27.2/13.2/6.0 (BP=0.985, ratio=0.985, hyp_len=783, ref_len=795)
ko2en : 23.82   +/-3.87 BLEU = 23.74, 56.7/31.7/18.0/9.8 (BP=1.000, ratio=1.018, hyp_len=1012, ref_len=994)

Use Mecab-ko Tokenization after OpenNMT Tokenization
en2ko : 29.27   +/-4.80 BLEU = 29.35, 66.0/37.1/22.1/13.7 (BP=1.000, ratio=1.008, hyp_len=839, ref_len=832)
ko2en : 41.07   +/-6.81 BLEU = 41.66, 72.6/50.2/34.3/24.1 (BP=1.000, ratio=1.011, hyp_len=1048, ref_len=1037)



