### PR TITLE
Fully ignore placeholders when learning BPE

### DIFF
--- a/tools/learn_bpe.lua
+++ b/tools/learn_bpe.lua
@@ -72,15 +72,15 @@ local opt = cmd:parse(arg)
 
 local function string2word(s)
   local t = {}
-  if opt.bpe_mode == 'prefix' or opt.bpe_mode == 'both' then table.insert(t, opt.bpe_BOT_marker) end
-  if s:sub(1, separators.ph_marker_open:len()) == separators.ph_marker_open then
-    table.insert(t, s)
-  else
-    for _, c in unicode.utf8_iter(s) do
-      table.insert(t, c)
-    end
+  if opt.bpe_mode == 'prefix' or opt.bpe_mode == 'both' then
+    table.insert(t, opt.bpe_BOT_marker)
   end
-  if opt.bpe_mode == 'suffix' or opt.bpe_mode == 'both' then table.insert(t, opt.bpe_EOT_marker) end
+  for _, c in unicode.utf8_iter(s) do
+    table.insert(t, c)
+  end
+  if opt.bpe_mode == 'suffix' or opt.bpe_mode == 'both' then
+    table.insert(t, opt.bpe_EOT_marker)
+  end
   return table.concat(t, " ")
 end
 
@@ -146,7 +146,9 @@ local function get_vocabulary()
     local words = onmt.utils.Features.extract(toks)
     for i = 1, #words do
       local word = words[i]
-      vocab[word] = (vocab[word] or 0) + 1
+      if not word:find(separators.ph_marker_open) then
+        vocab[word] = (vocab[word] or 0) + 1
+      end
     end
     l = io.read()
     count = count + 1


### PR DESCRIPTION
Until now, each placeholder had its own rule in the BPE model for the encoding to not split such token. However, all encoding scripts (here and in the Tokenizer) simply skip the protected sequence, making these rules unnecessary.

For consistency with our own tools, I propose to ignore all placeholders when learning the BPE model.

@jsenellart Does it make sense? Or would it be better to configure the behavior regarding placeholders with an option?