### PR TITLE
Dockerfile sentencepiece fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,9 @@ RUN git clone https://github.com/google/sentencepiece.git /root/sentencepiece-gi
     cd /root/sentencepiece-git && \
     mkdir build && \
     cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=/root/sentencepiece .. && \
+    cmake -DCMAKE_INSTALL_PREFIX=/root/sentencepiece .. && \
     make -j $(nproc) && \
     make install && \
-    ldconfig -v && \
     rm -r /root/sentencepiece-git
 
 RUN git clone https://github.com/OpenNMT/lua-sentencepiece.git /root/lua-sentencepiece && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,14 @@ RUN /root/torch/bin/luarocks install tds && \
 # Install lua-sentencepiece
 RUN git clone https://github.com/google/sentencepiece.git /root/sentencepiece-git && \
     cd /root/sentencepiece-git && \
-    ./autogen.sh && \
-    ./configure --prefix=/root/sentencepiece && \
-    make && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/root/sentencepiece .. && \
+    make -j $(nproc) && \
     make install && \
-    cd /root && \
+    ldconfig -v && \
     rm -r /root/sentencepiece-git
+
 RUN git clone https://github.com/OpenNMT/lua-sentencepiece.git /root/lua-sentencepiece && \
     cd /root/lua-sentencepiece && \
     CMAKE_LIBRARY_PATH=/root/sentencepiece/lib CMAKE_INCLUDE_PATH=/root/sentencepiece/include \


### PR DESCRIPTION
`sentencepiece` doesn't has `autogen.sh` anymore.
This PR updates the way how it must be installed.